### PR TITLE
Fix memory overflow of extract for 2D mesh

### DIFF
--- a/examples++-load/msh3.cpp
+++ b/examples++-load/msh3.cpp
@@ -5949,7 +5949,7 @@ AnyType ExtractMesh2D_Op::operator () (Stack stack)  const {
 		R2 Pn, Px;
 		pThnew->BoundingBox(Pn, Px);
 		if (!pThnew->quadtree) {
-			pThnew->quadtree = new Fem2D::FQuadTree(pTh, Pn, Px, pTh->nv);
+			pThnew->quadtree = new Fem2D::FQuadTree(pThnew, Pn, Px, pThnew->nv);
 		}
 
 		// Lorenzo


### PR DESCRIPTION
Can anyone check that is the good behavior ?
(Who write this function?)

The previous version leads to memory overflow, see [#26](https://github.com/FreeFem/FreeFem-sources/issues/26)