### PR TITLE
Fix typos in two tests

### DIFF
--- a/examples++-load/NSP2BRP0.edp
+++ b/examples++-load/NSP2BRP0.edp
@@ -1,4 +1,4 @@
-load "BernadiRaugel"
+load "BernardiRaugel"
 // remark: the sign of p is correct 
 real s0=clock();
 mesh Th=square(2,2);

--- a/examples++-load/testFE.edp
+++ b/examples++-load/testFE.edp
@@ -1,4 +1,4 @@
-load "BernadiRaugel"
+load "BernardiRaugel"
 // a macro the compute numerical derivative
 macro DD(f,hx,hy) ( (f(x1+hx,y1+hy)-f(x1-hx,y1-hy))/(2*(hx+hy))) //
 mesh Th=square(1,1,[10*(x+y/3),10*(y-x/3)]);


### PR DESCRIPTION
These two tests are not activated in FreeFem++ but they seem to work when a small typo is fixed in each file. This pull request only fix typos but I can update examples++-load/Makefile if needed.