### PR TITLE
fix new hdf5 version bug on Arch

### DIFF
--- a/ax_lib_hdf5.m4
+++ b/ax_lib_hdf5.m4
@@ -177,7 +177,7 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
         HDF5_SHOW=$(eval $H5CC -show)
 
         dnl Get the actual compiler used
-        HDF5_CC=$(eval $H5CC -show | $AWK '{print $[]1}')
+        HDF5_CC=$(eval $H5CC -show | $AWK '{print $[]1; exit}')
         if test "$HDF5_CC" = "ccache"; then
             HDF5_CC=$(eval $H5CC -show | $AWK '{print $[]2}')
         fi


### PR DESCRIPTION
`awk` previously do not exit after read the first line returned by `h5cc`.
That fix the hdf5 1.10.3-1 bug in configure, no idea for other OS.

@frederichecht could you try it on your Mac (branch feature-hdf5) ?