### PR TITLE
Update for FreeBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,7 +278,7 @@ install-exec-local:: bin/script/PostInstall.sh FreeFEM-documentation.pdf
 	cd idp; for i in *.idp; do \
 	 if [ -f $$i ] ; then 	$(INSTALL)  -m 555 $$i $(DESTDIR)$(ff_prefix_dir)/idp; fi; done
 
-bin/script/PostInstall.sh:./Makefile bin/script/PostInstall.m4Makefile.am
+bin/script/PostInstall.sh:./Makefile bin/script/PostInstall.m4
 	m4 "-DFF__FVER=$(PACKAGE_VERSION)" "-DFF_BINDIR=$(bindir)" "-DFF__DATADIR=$(pkgdatadir)" bin/script/PostInstall.m4 > bin/script/PostInstall.sh
 	chmod a+x bin/script/PostInstall.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -279,7 +279,7 @@ install-exec-local:: bin/script/PostInstall.sh FreeFEM-documentation.pdf
 	 if [ -f $$i ] ; then 	$(INSTALL)  -m 555 $$i $(DESTDIR)$(ff_prefix_dir)/idp; fi; done
 
 bin/script/PostInstall.sh:./Makefile bin/script/PostInstall.m4Makefile.am
-	m4 "-bin/script/PostInstall.m4DFF__FVER=$(PACKAGE_VERSION)" "-DFF_BINDIR=$(bindir)" "-DFF__DATADIR=$(pkgdatadir)" bin/script/PostInstall.m4 > bin/script/PostInstall.sh
+	m4 "-DFF__FVER=$(PACKAGE_VERSION)" "-DFF_BINDIR=$(bindir)" "-DFF__DATADIR=$(pkgdatadir)" bin/script/PostInstall.m4 > bin/script/PostInstall.sh
 	chmod a+x bin/script/PostInstall.sh
 
 FreeFEM-documentation.pdf:Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -278,8 +278,8 @@ install-exec-local:: bin/script/PostInstall.sh FreeFEM-documentation.pdf
 	cd idp; for i in *.idp; do \
 	 if [ -f $$i ] ; then 	$(INSTALL)  -m 555 $$i $(DESTDIR)$(ff_prefix_dir)/idp; fi; done
 
-bin/script/PostInstall.sh:./Makefile bin/script/PostInstall.m4
-	m4 bin/script/PostInstall.m4 "-DFF__FVER=$(PACKAGE_VERSION)" "-DFF_BINDIR=$(bindir)" "-DFF__DATADIR=$(pkgdatadir)" > bin/script/PostInstall.sh
+bin/script/PostInstall.sh:./Makefile bin/script/PostInstall.m4Makefile.am
+	m4 "-bin/script/PostInstall.m4DFF__FVER=$(PACKAGE_VERSION)" "-DFF_BINDIR=$(bindir)" "-DFF__DATADIR=$(pkgdatadir)" bin/script/PostInstall.m4 > bin/script/PostInstall.sh
 	chmod a+x bin/script/PostInstall.sh
 
 FreeFEM-documentation.pdf:Makefile

--- a/bin/script/PostInstall.m4
+++ b/bin/script/PostInstall.m4
@@ -20,7 +20,6 @@ if [ -d  /usr/local/bin ] ; then
   cd /usr/local/bin
   for i in  FreeFem++ FreeFem++-CoCoa FreeFem++-mpi FreeFem++-nw bamg cvmsh2 ff-c++ ff-get-dep ff-mpirun ff-pkg-download ffglut ffmedit; 
   do 
-
       if [  -f  "$i" ] ; then 
 	  echo " clean $i "
 	  rm "$i";
@@ -28,8 +27,8 @@ if [ -d  /usr/local/bin ] ; then
   done
 
   if [ "$(uname)" = "Darwin" ]; then
-    echo ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
-    ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
+      echo ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
+      ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
   fi
 fi
 # bluid new link to new 

--- a/bin/script/PostInstall.m4
+++ b/bin/script/PostInstall.m4
@@ -3,14 +3,18 @@
 # "-DFF_BINDIR=$(bindir)" 
 # "-DFF__DATADIR=$(pkgdatadir)
 #  "FFBIN="@prefix@"/bin
-ff_desktop="$HOME/Desktop/FreeFem++-""FF__FVER"
-mkdir -p -m 0755 /etc/paths.d
-ln -sf "FF__DATADIR"/"freefem++doc.pdf" "$HOME/Desktop"
-test -e "$ff_desktop" || ln -sf "FF__DATADIR"/"FF__FVER" "$ff_desktop"
-echo Install /etc/paths.d/FreeFem++ file:  "FF_BINDIR"
 
-echo "FF_BINDIR" > /etc/paths.d/FreeFem++
-chmod a+r /etc/paths.d/FreeFem++
+if [ "$(uname)" = "Darwin" ]; then
+  ff_desktop="$HOME/Desktop/FreeFem++-""FF__FVER"
+  mkdir -p -m 0755 /etc/paths.d
+  ln -sf "FF__DATADIR"/"freefem++doc.pdf" "$HOME/Desktop"
+  test -e "$ff_desktop" || ln -sf "FF__DATADIR"/"FF__FVER" "$ff_desktop"
+  echo Install /etc/paths.d/FreeFem++ file:  "FF_BINDIR"
+
+  echo "FF_BINDIR" > /etc/paths.d/FreeFem++
+  chmod a+r /etc/paths.d/FreeFem++
+fi
+
 echo " Try to Clean old file version "
 if [ -d  /usr/local/bin ] ; then  
   cd /usr/local/bin
@@ -23,10 +27,10 @@ if [ -d  /usr/local/bin ] ; then
       fi
   done
 
-
-echo ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
-ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
-
+  if [ "$(uname)" = "Darwin" ]; then
+    echo ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
+    ln -s FF_BINDIR/FreeFem++-CoCoa  /usr/local/bin/ 
+  fi
 fi
 # bluid new link to new 
 

--- a/src/femlib/CheckPtr.cpp
+++ b/src/femlib/CheckPtr.cpp
@@ -27,6 +27,8 @@
  */
 #if __APPLE__
 #include <malloc/malloc.h>
+#elif __FreeBSD__
+#include <stdlib.h>
 #else
 #include <malloc.h>
 #endif

--- a/src/femlib/CheckPtr.cpp
+++ b/src/femlib/CheckPtr.cpp
@@ -25,13 +25,8 @@
  void* operator new (std::size_t size, const std::nothrow_t& nothrow_value) noexcept;
  p
  */
-#if __APPLE__
-#include <malloc/malloc.h>
-#elif __FreeBSD__
-#include <stdlib.h>
-#else
-#include <malloc.h>
-#endif
+
+#include <cstdlib>
 
 static long verbosity;
 


### PR DESCRIPTION
In FreeBSD, <malloc.h> has been abolished and <stdlib.h> has been used.