### PR TITLE
Chop off directory prefix from the file name (-cd)

### DIFF
--- a/src/Graphics/getprog-unix.hpp
+++ b/src/Graphics/getprog-unix.hpp
@@ -241,6 +241,7 @@ check_plugin=0; // no pluging to check ..
     if (i > 0) {
       char *dir = new char[l + 1];
       strcpy(dir, edpfilenamearg);
+      strcyp(fn,  edpfilenamearg+i+1);
       dir[i] = 0;
       int err = 0;
       if (verbosity > 1)


### PR DESCRIPTION
FreeFem++ -cd  ../t.edp
Right now it correctly chdir to the parent directory of the file (.. here), but fails to chop off the directory name from the file address. Then tries to call FreeFem++ ../t.edp.

It should call FreeFem++ t.epd