### PR TITLE
Added verbosity condition to console output when saving .mesh file

### DIFF
--- a/src/bamglib/MeshWrite.cpp
+++ b/src/bamglib/MeshWrite.cpp
@@ -150,7 +150,7 @@ namespace bamg {
               strcpy(Gh.name + lll - ls, gsuffix + 1);
             else
               strcpy(Gh.name + lll - ls, gsuffix);
-            cout << " write geo in " << Gh.name << endl;
+            if(verbosity > 1) cout << " write geo in " << Gh.name << endl;
             ofstream f(Gh.name);
             f << Gh;
             Gh.OnDisk = true;


### PR DESCRIPTION
The text "write geo in <mesh_file_name>.gmsh" will now appear in console output only if verbosity is set to 1 or more.