### PR TITLE
Find petsc on Debian system.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -988,7 +988,7 @@ if test "$with_petsc" != no; then
 	    ffconfpetsc="$d$dd"
 		ffconfslepc="$d/slepc/conf/slepcvariables"
 
-		echo " petsc ... $ffconfpetsc"
+		# echo " petsc ... $ffconfpetsc"
 	    if test -f "$ffconfpetsc" ; then
 		if test  "$ff_petsc_ok" = no ; then
 		    PETSC_PREFIXDIR=`awk -F' *= *' '"PREFIXDIR"==$1 {print $2}' "$ffconfpetsc"`

--- a/configure.ac
+++ b/configure.ac
@@ -983,12 +983,12 @@ AC_SUBST([FF_generic_petsc],"$enable_generic")
 ff_petsc_ok=no
 ff_slepc_ok=no
 if test "$with_petsc" != no; then
-    for d in "$with_petsc" "${prefix_petsc}/r/lib" /usr/local/ff++/petsc/lib  /usr /usr/local /opt/usr  /opt/local ;do
+    for d in "$with_petsc" "${prefix_petsc}/r/lib" /usr/local/ff++/petsc/lib  /usr /usr/local /opt/usr  /opt/local /usr/lib/petsc ;do
 	for dd in "" "/petsc/conf/petscvariables" "/lib/petsc/conf/petscvariables" ; do
 	    ffconfpetsc="$d$dd"
 		ffconfslepc="$d/slepc/conf/slepcvariables"
 
-		# echo " petsc ... $ffconfpetsc"
+		echo " petsc ... $ffconfpetsc"
 	    if test -f "$ffconfpetsc" ; then
 		if test  "$ff_petsc_ok" = no ; then
 		    PETSC_PREFIXDIR=`awk -F' *= *' '"PREFIXDIR"==$1 {print $2}' "$ffconfpetsc"`
@@ -1086,7 +1086,7 @@ AC_ARG_WITH(petsc_complex,[  --with-petsc_complex=/usr/local/petsc/conf/petscvar
 ff_petsccomplex_ok=no
 ff_slepccomplex_ok=no
 if test "$with_petsc_complex" != no; then
-    for d in "$with_petsc_complex" "${prefix_petsc}/c/lib" /usr/local/ff++/petsc/c/lib ;do
+    for d in "$with_petsc_complex" "${prefix_petsc}/c/lib" /usr/local/ff++/petsc/c/lib /usr/lib/petsc ;do
 	for dd in "" "/petsc/conf/petscvariables" "/lib/petsc/conf/petscvariables" ; do
 	    ffconfpetscc="$d$dd"
 	    if test -f "$ffconfpetscc" -a  "$ff_petsccomplex_ok" = no ; then


### PR DESCRIPTION
On Debian distribution, petsc is installed under `/usr/lib/petsc` so it has to be added to `configure.ac`, otherwise petsc is not found by the configuration system.

Thanks