### PR TITLE
Fixed the missing character in dirname

### DIFF
--- a/plugin/seq/shell.cpp
+++ b/plugin/seq/shell.cpp
@@ -211,9 +211,9 @@ string dirname(const string *ppath) {
     }
   }
 
-  if (i == 0) {
+  if (i == -1) {
     return ".";
-  } else if (i == 1) {
+  } else if (i == 0) {
     return "/";
   } else {
     return path.substr(0, i);

--- a/plugin/seq/shell.cpp
+++ b/plugin/seq/shell.cpp
@@ -216,7 +216,7 @@ string dirname(const string *ppath) {
   } else if (i == 1) {
     return "/";
   } else {
-    return path.substr(0, i - 1);
+    return path.substr(0, i);
   }
 }
 


### PR DESCRIPTION
The directory name miss a character. For example, using the original shell file, the return value of the `dirname` is `/home/zhaog6/tes` when the edp file to edit is in `/home/zhaog6/test`. The wrong occur on line 219 in shell.cpp.

The PR fixs right side of substring of `path` because `substr` is closed on the left side and open on the right side.