### PR TITLE
Replaced several occurrences of "Foobar" by "FreeFEM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <!--- GNU Lesser General Public License for more details.                         --->
 <!---                                                                             --->
 <!--- You should have received a copy of the GNU Lesser General Public License    --->
-<!--- along with Foobar.  If not, see <http://www.gnu.org/licenses/>.             --->
+<!--- along with FreeFEM.  If not, see <http://www.gnu.org/licenses/>.            --->
 <!----------------------------------------------------------------------------------->
 
 <details>

--- a/readme/README_COMPILATION.md
+++ b/readme/README_COMPILATION.md
@@ -3,18 +3,18 @@
 <!--- Laboratoire Jacques-Louis Lions                                             --->
 <!--- Sorbonne Université, UMR 7598, Paris, F-75005 France                        --->
 <!---                                                                             --->
-<!--- Foobar is free software: you can redistribute it and/or modify              --->
+<!--- FreeFEM is free software: you can redistribute it and/or modify             --->
 <!--- it under the terms of the GNU Lesser General Public License as published by --->
 <!--- the Free Software Foundation, either version 3 of the License, or           --->
 <!--- (at your option) any later version.                                         --->
 <!---                                                                             --->
-<!--- Foobar is distributed in the hope that it will be useful,                   --->
+<!--- FreeFEM is distributed in the hope that it will be useful,                  --->
 <!--- but WITHOUT ANY WARRANTY; without even the implied warranty of              --->
 <!--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               --->
 <!--- GNU Lesser General Public License for more details.                         --->
 <!---                                                                             --->
 <!--- You should have received a copy of the GNU Lesser General Public License    --->
-<!--- along with Foobar.  If not, see <http://www.gnu.org/licenses/>.             --->
+<!--- along with FreeFEM.  If not, see <http://www.gnu.org/licenses/>.            --->
 <!----------------------------------------------------------------------------------->
 
 # Compilation of FreeFem++ and bamg (mesh generator) under Unix, MacOs X or MinGW (Windows)

--- a/readme/README_GIT.md
+++ b/readme/README_GIT.md
@@ -3,18 +3,18 @@
 <!--- Laboratoire Jacques-Louis Lions                                             --->
 <!--- Sorbonne Université, UMR 7598, Paris, F-75005 France                        --->
 <!---                                                                             --->
-<!--- Foobar is free software: you can redistribute it and/or modify              --->
+<!--- FreeFEM is free software: you can redistribute it and/or modify             --->
 <!--- it under the terms of the GNU Lesser General Public License as published by --->
 <!--- the Free Software Foundation, either version 3 of the License, or           --->
 <!--- (at your option) any later version.                                         --->
 <!---                                                                             --->
-<!--- Foobar is distributed in the hope that it will be useful,                   --->
+<!--- FreeFEM is distributed in the hope that it will be useful,                  --->
 <!--- but WITHOUT ANY WARRANTY; without even the implied warranty of              --->
 <!--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               --->
 <!--- GNU Lesser General Public License for more details.                         --->
 <!---                                                                             --->
 <!--- You should have received a copy of the GNU Lesser General Public License    --->
-<!--- along with Foobar.  If not, see <http://www.gnu.org/licenses/>.             --->
+<!--- along with FreeFEM.  If not, see <http://www.gnu.org/licenses/>.            --->
 <!----------------------------------------------------------------------------------->
 
 

--- a/readme/README_MAC.md
+++ b/readme/README_MAC.md
@@ -3,18 +3,18 @@
 <!--- Laboratoire Jacques-Louis Lions                                             --->
 <!--- Sorbonne Université, UMR 7598, Paris, F-75005 France                        --->
 <!---                                                                             --->
-<!--- Foobar is free software: you can redistribute it and/or modify              --->
+<!--- FreeFEM is free software: you can redistribute it and/or modify             --->
 <!--- it under the terms of the GNU Lesser General Public License as published by --->
 <!--- the Free Software Foundation, either version 3 of the License, or           --->
 <!--- (at your option) any later version.                                         --->
 <!---                                                                             --->
-<!--- Foobar is distributed in the hope that it will be useful,                   --->
+<!--- FreeFEM is distributed in the hope that it will be useful,                  --->
 <!--- but WITHOUT ANY WARRANTY; without even the implied warranty of              --->
 <!--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               --->
 <!--- GNU Lesser General Public License for more details.                         --->
 <!---                                                                             --->
 <!--- You should have received a copy of the GNU Lesser General Public License    --->
-<!--- along with Foobar.  If not, see <http://www.gnu.org/licenses/>.             --->
+<!--- along with FreeFEM.  If not, see <http://www.gnu.org/licenses/>.            --->
 <!----------------------------------------------------------------------------------->
 
 # How to compile FreeFem++ on MacOSX

--- a/readme/README_WINDOWS.md
+++ b/readme/README_WINDOWS.md
@@ -3,18 +3,18 @@
 <!--- Laboratoire Jacques-Louis Lions                                             --->
 <!--- Sorbonne Université, UMR 7598, Paris, F-75005 France                        --->
 <!---                                                                             --->
-<!--- Foobar is free software: you can redistribute it and/or modify              --->
+<!--- FreeFEM is free software: you can redistribute it and/or modify             --->
 <!--- it under the terms of the GNU Lesser General Public License as published by --->
 <!--- the Free Software Foundation, either version 3 of the License, or           --->
 <!--- (at your option) any later version.                                         --->
 <!---                                                                             --->
-<!--- Foobar is distributed in the hope that it will be useful,                   --->
+<!--- FreeFEM is distributed in the hope that it will be useful,                  --->
 <!--- but WITHOUT ANY WARRANTY; without even the implied warranty of              --->
 <!--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               --->
 <!--- GNU Lesser General Public License for more details.                         --->
 <!---                                                                             --->
 <!--- You should have received a copy of the GNU Lesser General Public License    --->
-<!--- along with Foobar.  If not, see <http://www.gnu.org/licenses/>.             --->
+<!--- along with FreeFEM.  If not, see <http://www.gnu.org/licenses/>.            --->
 <!----------------------------------------------------------------------------------->
 
 # How to compile FreeFem++ on Microsoft Windows

--- a/readme/README_XCODE.md
+++ b/readme/README_XCODE.md
@@ -3,18 +3,18 @@
 <!--- Laboratoire Jacques-Louis Lions                                             --->
 <!--- Sorbonne Université, UMR 7598, Paris, F-75005 France                        --->
 <!---                                                                             --->
-<!--- Foobar is free software: you can redistribute it and/or modify              --->
+<!--- FreeFEM is free software: you can redistribute it and/or modify             --->
 <!--- it under the terms of the GNU Lesser General Public License as published by --->
 <!--- the Free Software Foundation, either version 3 of the License, or           --->
 <!--- (at your option) any later version.                                         --->
 <!---                                                                             --->
-<!--- Foobar is distributed in the hope that it will be useful,                   --->
+<!--- FreeFEM is distributed in the hope that it will be useful,                  --->
 <!--- but WITHOUT ANY WARRANTY; without even the implied warranty of              --->
 <!--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               --->
 <!--- GNU Lesser General Public License for more details.                         --->
 <!---                                                                             --->
 <!--- You should have received a copy of the GNU Lesser General Public License    --->
-<!--- along with Foobar.  If not, see <http://www.gnu.org/licenses/>.             --->
+<!--- along with FreeFEM.  If not, see <http://www.gnu.org/licenses/>.            --->
 <!----------------------------------------------------------------------------------->
 
 # The MacOS version can be built with Xcode


### PR DESCRIPTION
I assume the word "Foobar" is coming from the LGPL license template.
It was left untouched at some occurrences in the readme files.

I am aware of the rule "don't push to master" but I believe this is an exception and these changes belong there.