### PR TITLE
Fixed a bug of setenv in shell.edp

### DIFF
--- a/examples/plugin/shell.edp
+++ b/examples/plugin/shell.edp
@@ -12,7 +12,6 @@ while(1)
 
 cout << " login " << getenv("LOGIN") << endl;
 setenv("FF_TOTO","toto");
-setenv("FF_TOTO","toto");
 cout << " FF_TOTO  " << getenv("FF_TOTO") << endl;
 string pwd=getenv("PWD");
 verbosity=3;

--- a/plugin/seq/shell.cpp
+++ b/plugin/seq/shell.cpp
@@ -151,12 +151,12 @@ string *ffgetenv(Stack s, string *const &k) {
 }
 
 long ffsetenv(string *const &k, string *const &v) {
-  char *vv = strcpy((char *)malloc(v->size( ) + 2), v->c_str( ));
   char *kk = strcpy((char *)malloc(k->size( ) + 2), k->c_str( ));
+  char *vv = strcpy((char *)malloc(v->size( ) + 2), v->c_str( ));
 
-  SetEnvironmentVariable(vv, kk);
-  free(vv);
+  SetEnvironmentVariable(kk, vv);
   free(kk);
+  free(vv);
   return 0;
 }
 
@@ -177,12 +177,12 @@ string *ffgetenv(Stack s, string *const &k) {
 }
 
 long ffsetenv(string *const &k, string *const &v) {
-  char *vv = strcpy((char *)malloc(v->size( ) + 2), v->c_str( ));
   char *kk = strcpy((char *)malloc(k->size( ) + 2), k->c_str( ));
-  long r = setenv(vv, kk, 1);
+  char *vv = strcpy((char *)malloc(v->size( ) + 2), v->c_str( ));
+  long r = setenv(kk, vv, 1);
 
-  free(vv);
   free(kk);
+  free(vv);
   return r;
 }
 


### PR DESCRIPTION
A bug of parameter order of `setenv` in this PR is fixed. For the example `shell.edp` in `examples/plugin/`, the original code will not yield any results when users calling `setenv("FF_TOTO", "toto")` and `getenv("FF_TOTO")`.