### PR TITLE
Suppress cout when verbosity == 0

### DIFF
--- a/src/femlib/fem.cpp
+++ b/src/femlib/fem.cpp
@@ -1819,7 +1819,7 @@ Mesh::Mesh(const Mesh & Th,int * split,bool WithMortar,int label)
             cerr << " The generatated 2d mesh is to fine :  hmin = " << hm << " to to small < "<< 1./quadtree->coef  << endl;
             ffassert(0); 
         }
-        if(verbosity>5 || ! iseuil )
+        if( verbosity>5 && ! iseuil )
          cout << " seuil = " <<  seuil << " hmin = " << hm << " iseuil/ quadtree: " << iseuil << " coef quadtree " <<  quadtree->coef << endl;
 
        //      ffassert(iseuil); //  zero => too smal


### PR DESCRIPTION
I'm not sure what the desired functionality here is, should this be `(verbosity>5 && ! iseuil) ` or simply `(verbosity>5)`?