### PR TITLE
Remove obsolete unary and binary functions.

### DIFF
--- a/plugin/seq/msh3.cpp
+++ b/plugin/seq/msh3.cpp
@@ -1981,12 +1981,18 @@ Mesh3 *GluMesh3(listMesh3 const &lst) {
 }
 
 template< class RR, class AA = RR, class BB = AA >
-struct Op3_addmesh : public binary_function< AA, BB, RR > {
+struct Op3_addmesh {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(Stack s, const AA &a, const BB &b) { return RR(s, a, b); }
 };
 
 template< bool INIT, class RR, class AA = RR, class BB = AA >
-struct Op3_setmesh : public binary_function< AA, BB, RR > {
+struct Op3_setmesh {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(Stack stack, const AA &a, const BB &b) {
     ffassert(a);
     const pmesh3 p = GluMesh3(b);
@@ -2362,12 +2368,18 @@ MeshL *GluMesh(listMeshT<MeshL> const &lst) {
 
 
 template< class RR, class AA = RR, class BB = AA >
-struct Op3_addmeshS : public binary_function< AA, BB, RR > {
+struct Op3_addmeshS {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(Stack s, const AA &a, const BB &b) { return RR(s, a, b); }
 };
 
 template< bool INIT, class RR, class AA = RR, class BB = AA >
-struct Op3_setmeshS : public binary_function< AA, BB, RR > {
+struct Op3_setmeshS {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(Stack stack, const AA &a, const BB &b) {
     ffassert(a);
     const pmeshS p = GluMesh(b);
@@ -2381,12 +2393,18 @@ struct Op3_setmeshS : public binary_function< AA, BB, RR > {
 
 
 template< class RR, class AA = RR, class BB = AA >
-struct Op3_addmeshL : public binary_function< AA, BB, RR > {
+struct Op3_addmeshL {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
     static RR f(Stack s, const AA &a, const BB &b) { return RR(s, a, b); }
 };
 
 template< bool INIT, class RR, class AA = RR, class BB = AA >
-struct Op3_setmeshL : public binary_function< AA, BB, RR > {
+struct Op3_setmeshL {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
     static RR f(Stack stack, const AA &a, const BB &b) {
         ffassert(a);
         const pmeshL p = GluMesh(b);

--- a/src/fflib/AFunction.cpp
+++ b/src/fflib/AFunction.cpp
@@ -148,7 +148,10 @@ template<class T> inline T Max (const T &a,const T & b,const T & c,const T & d){
 
 template<class T> inline T Square (const T &a){return a*a;}
 
-struct SubArray2: public binary_function<long,long,SubArray> {
+struct SubArray2 {
+  using first_argument_type  = long;
+  using second_argument_type = long;
+  using result_type          = SubArray;
   static SubArray f(const long & a,const long & b)  {
     return SubArray(b-a+1,a);} };
 struct SubArray3: public ternary_function<long,long,long,SubArray> {
@@ -236,12 +239,17 @@ R *MakePtrWithDel( A  const & a)
   return r;}
 
 template<class R,class RR>
-struct Op1_new_pstring: public unary_function<string*,R> {
+struct Op1_new_pstring{
+  using argument_type  = string*;
+  using result_type    = R;
   static R f(string * const & a)  {R r =  new RR(a->c_str());
     return r;} };
 
 template<class R,class RR>
-struct Op2_set_pstring: public binary_function<R,string*,R> {
+struct Op2_set_pstring {
+  using first_argument_type  = R;
+  using second_argument_type = string*;
+  using result_type          = R;
   static R  f(R const & p,string * const & a)  {*p =  new RR(a->c_str());
    if ( !*p || !**p) {
        cerr << " Error opening file " << *a << endl;

--- a/src/fflib/AFunction.hpp
+++ b/src/fflib/AFunction.hpp
@@ -183,8 +183,11 @@ Expression NewExpression(Function2,Expression,Expression);
 inline Type_Expr make_Type_Expr(aType t, E_F0  * e) {return make_pair(t,e);}
 inline Type_Expr make_Type_Expr( E_F0  * e,aType t) {return make_pair(t,e);}
 
-struct Keyless : binary_function<const char *,const char *, bool>
+struct Keyless
    { 
+    using first_argument_type  = const char *;
+    using second_argument_type = const char *;
+    using result_type          = bool;
     typedef const char * Key;
     bool operator()(const Key& x, const Key& y) const { return strcmp(x,y)<0;} };
     
@@ -372,8 +375,12 @@ class E_F0 :public CodeAlloc
    {
    public:
        static E_F0 *tnull;
-  struct kless : binary_function<Expression,Expression, bool>
-   { bool operator()(const Expression& x, const Expression& y) const{ 
+  struct kless
+   {
+     using first_argument_type  = Expression;
+     using second_argument_type = Expression;
+     using result_type          = bool;
+     bool operator()(const Expression& x, const Expression& y) const{
      //cout << x << " " << y << x->compare(y) << " ::: ";
       int r1 = x->compare(y);// , r2 = y->compare(x);
      //assert(r1+r2==0);

--- a/src/fflib/Operator.hpp
+++ b/src/fflib/Operator.hpp
@@ -35,47 +35,74 @@ inline double pow(double x,long l) { return pow(x,(double)l);}
 
 
 template<class R,class A=R> 
-struct Op1_neg: public unary_function<A,R> { 
+struct Op1_neg {
+  using argument_type  = A;
+  using result_type    = R;
   static R f(const A & a)  { return - (R)a;} }; 
   
 template<class R,class A=R> 
-struct Op1_plus: public unary_function<A,R> { 
+struct Op1_plus{
+  using argument_type  = A;
+  using result_type    = R;
   static R f(const A & a)  { return + (R)a;} }; 
   
 template<class A> 
-struct Op1_not: public unary_function<A,bool> { 
+struct Op1_not{
+  using argument_type  = A;
+  using result_type    = bool;
   static bool f(const A & a)  { return ! (bool)a;} }; 
   
 template<class R,class A=R,class B=A> 
-struct Op2_add: public binary_function<A,B,R> { 
+struct Op2_add {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return ((R)a + (R)b);} }; 
 
 template<class R,class A=R,class B=A> 
-struct Op2_sub: public binary_function<A,B,R> { 
+struct Op2_sub {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return ((R)a - (R)b);} }; 
 
 template<class R,class A=R,class B=A>
-struct Op2_DotDiv: public binary_function<A,B,R> {
+struct Op2_DotDiv {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return DotDiv((R)a, (R)b);} };
 
 template<class R,class A=R,class B=A>
-struct Op2_DotStar: public binary_function<A,B,R> {
+struct Op2_DotStar {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return DotStar((R)a, (R)b);} };
 
 
 template<class R,class A=R,class B=A>
-struct Op2_mul: public binary_function<A,B,R> {
+struct Op2_mul {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  {
   // cout << a << " * " << b <<" => "  << ((R)a * (R)b) << endl;
   return ((R)a * (R)b);} }; 
 template<class R,class A,class B>
-struct Op2_mull: public binary_function<A,B,R> {
+struct Op2_mull {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  {
   // cout << a << " * " << b <<" => "  << ((R)a * (R)b) << endl;
   return (a * b);} };
 
 template<class R,class A=R,class B=A>
-struct Op2_div: public binary_function<A,B,R> {
+struct Op2_div {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  {
      if (b == B())
        {cerr <<  a << "/" << b << " : " <<  typeid(A).name()  << " " << typeid(B).name() 
@@ -83,7 +110,10 @@ struct Op2_div: public binary_function<A,B,R> {
      return ((R)a / (R)b);} };
 
 template<class R,class A,class B >
-struct Op2_divv: public binary_function<A,B,R> {
+struct Op2_divv {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  {
      if (b == B())
        {cerr <<  a << "/" << b << " : " <<  typeid(A).name()  << " " << typeid(B).name()
@@ -91,52 +121,85 @@ struct Op2_divv: public binary_function<A,B,R> {
      return (a / b);} };
 
 template<class R>
-struct Op2_pipe: public binary_function<R,R,R> {
+struct Op2_pipe {
+  using first_argument_type  = R;
+  using second_argument_type = R;
+  using result_type          = R;
     static R f(const R & a,const R & b)  {   return (a | b);} };
 
 template<class R,class A=R,class B=A> 
-struct Op2_mod: public binary_function<A,B,R> { 
+struct Op2_mod {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return ((R)a % (R)b);} }; 
 
 template<class A,class B=A> 
-struct Op2_lt: public binary_function<A,B,bool> { 
+struct Op2_lt {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { 
 //    cout << a << " < " << b << " = " << ( a<b) << endl;
     return a  < b;} }; 
 
 template<class A,class B=A> 
-struct Op2_le: public binary_function<A,B,bool> { 
+struct Op2_le {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { return a  <= b;} }; 
 
 
 template<class A,class B=A> 
-struct Op2_gt: public binary_function<A,B,bool> { 
+struct Op2_gt {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { return a  > b;} }; 
 
 
 template<class A,class B=A> 
-struct Op2_ge: public binary_function<A,B,bool> { 
+struct Op2_ge {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { return a  >= b;} }; 
 
 template<class A,class B=A> 
-struct Op2_eq: public binary_function<A,B,bool> { 
+struct Op2_eq {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b) 
    { //cout << a << " == " << b << " => " <<( a  == b) << endl;
    return a  == b;} }; 
 
 template<class A,class B=A> 
-struct Op2_ne: public binary_function<A,B,bool> { 
+struct Op2_ne {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { return a  != b;} }; 
 
-struct Op2_and: public binary_function<bool,bool,bool> { 
+struct Op2_and {
+  using first_argument_type  = bool;
+  using second_argument_type = bool;
+  using result_type          = bool;
   static bool f(const bool & a,const bool & b)  { return a  && b;} }; 
   
-struct Op2_or: public binary_function<bool,bool,bool> { 
+struct Op2_or {
+  using first_argument_type  = bool;
+  using second_argument_type = bool;
+  using result_type          = bool;
   static bool f(const bool & a,const bool & b)  { return a  || b;} }; 
 
 
 template<class R,class A,class B> 
-struct Op2_padd: public binary_function<A,B,R*> { 
+struct Op2_padd {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R * f(Stack s,const A & a,const B & b)  { 
    R* r= Add2StackOfPtr2Free(s, a || b ? new R ((a ? *a : nullptr) + (b ? *b : nullptr)) : nullptr);
   // delete a,delete b;
@@ -144,52 +207,76 @@ struct Op2_padd: public binary_function<A,B,R*> {
 
 
 template<class A,class B=A> 
-struct Op2_plt: public binary_function<A,B,bool> { 
+struct Op2_plt {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { bool r= *a  < *b;
   //delete a,delete b;
   return r;} }; 
 
 template<class A,class B=A> 
-struct Op2_ple: public binary_function<A,B,bool> { 
+struct Op2_ple {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { bool r= *a  <= *b;
   // delete a,delete b;
   return r;} }; 
 
 
 template<class A,class B=A> 
-struct Op2_pgt: public binary_function<A,B,bool> { 
+struct Op2_pgt {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { bool r= *a  > *b;
  // delete a,delete b;
   return r;} }; 
 
 
 template<class A,class B=A> 
-struct Op2_pge: public binary_function<A,B,bool> { 
+struct Op2_pge {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { bool r= *a  >= *b;
   // delete a,delete b;
   return r;} }; 
 
 template<class A,class B=A> 
-struct Op2_peq: public binary_function<A,B,bool> { 
+struct Op2_peq {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  { bool r= *a  == *b;
  //  delete a,delete b;
   return r;} }; 
 
 template<class A,class B=A> 
-struct Op2_pne: public binary_function<A,B,bool> { 
+struct Op2_pne {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = bool;
   static bool f(const A & a,const B & b)  {  bool r=*a  != *b;
   // delete a,delete b;
   return r;} }; 
 
 
 template<class R,class A=R,class B=A>
-struct Op2_pow: public binary_function<A,B,R> {
+struct Op2_pow {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return R(pow(a,b));}};
   
 
 
 template<class A>
-struct Op_Read : public binary_function<istream*,A*,istream*> {
+struct Op_Read {
+  using first_argument_type  = istream*;
+  using second_argument_type = A*;
+  using result_type          = istream*;
   static istream *  f(istream  * const  & f,A  * const  &  a)  
    {
        if( !f || !*f) ExecError("Fatal Error: file not open in read value (Op_Read)");
@@ -200,7 +287,10 @@ struct Op_Read : public binary_function<istream*,A*,istream*> {
 };
 
 template<class A>
-struct Op_ReadP : public binary_function<istream*,A**,istream*> {
+struct Op_ReadP {
+  using first_argument_type  = istream*;
+  using second_argument_type = A**;
+  using result_type          = istream*;
   static istream *  f(istream  * const  & f,A  ** const  &  a)  
    {
      assert(a);
@@ -213,7 +303,10 @@ struct Op_ReadP : public binary_function<istream*,A**,istream*> {
 };
 
 template<class A>
-struct Op_ReadKN : public binary_function<istream*,KN<A>*,istream*> {
+struct Op_ReadKN {
+  using first_argument_type  = istream*;
+  using second_argument_type = KN<A>*;
+  using result_type          = istream*;
   static istream *  f(istream  * const  & f,KN<A>* const  &  a)  
    { 
      if( !f || !*f) ExecError("Fatal Error: file not open in read array (Op_ReadKN)");
@@ -241,7 +334,10 @@ struct Op_ReadKN : public binary_function<istream*,KN<A>*,istream*> {
    }
 };
 template<class A>
-struct Op_ReadKNM : public binary_function<istream*,KNM<A>*,istream*> {
+struct Op_ReadKNM {
+  using first_argument_type  = istream*;
+  using second_argument_type = KNM<A>*;
+  using result_type          = istream*;
     static istream *  f(istream  * const  & f,KNM<A>* const  &  a)
     {
         if( !f || !*f) ExecError("Fatal Error: file not open in read array (Op_ReadKNM)");
@@ -272,7 +368,10 @@ struct Op_ReadKNM : public binary_function<istream*,KNM<A>*,istream*> {
 
 
 template<class A>
-struct Op_WriteKNM : public binary_function<ostream*,KNM<A>*,ostream*> {
+struct Op_WriteKNM {
+  using first_argument_type  = ostream*;
+  using second_argument_type = KNM<A>*;
+  using result_type          = ostream*;
     static ostream *  f(ostream  * const  & f,KNM<A>* const  &  a) {
         *f << *a;
         return f;
@@ -281,7 +380,10 @@ struct Op_WriteKNM : public binary_function<ostream*,KNM<A>*,ostream*> {
 
 
 template<class A>
-struct Op_WriteKN : public binary_function<ostream*,KN<A>*,ostream*> {
+struct Op_WriteKN {
+  using first_argument_type  = ostream*;
+  using second_argument_type = KN<A>*;
+  using result_type          = ostream*;
     static ostream *  f(ostream  * const  & f,KN<A>* const  &  a) {
          *f << *a;
         return f;
@@ -318,48 +420,75 @@ struct Op_WriteKN<double> : public binary_function<ostream*,KN<double>*,ostream*
 };
 */
 template<class A>
-struct Print: public binary_function<ostream*,A,ostream*> {
+struct Print {
+  using first_argument_type  = ostream*;
+  using second_argument_type = A;
+  using result_type          = ostream*;
   static ostream* f(ostream* const  & a,const A & b)  { *a << b;  return a;}
 };
 
 //  ---------------------------------------------
 template<class A>
-struct set_eq: public binary_function<A*,A,A*> {
+struct set_eq {
+  using first_argument_type  = A*;
+  using second_argument_type = A;
+  using result_type          = A*;
   static A* f(A* const  & a,const A & b)  { *a = b; return a;}
 };
 
 template<class A,class B>
-struct set_eqq: public binary_function<A,B,A> {
+struct set_eqq {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(const A & a,const B & b)  {A aa(a); aa = b; return aa;}
 };
 
 template<class A,class B>
-struct set_eqq_add: public binary_function<A,B,A> {
+struct set_eqq_add {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(const A & a,const B & b)  {A aa(a); aa += b; return aa;}
 };
 
 template<class A>
-struct set_eq_add: public binary_function<A*,A,A*> {
+struct set_eq_add {
+  using first_argument_type  = A*;
+  using second_argument_type = A;
+  using result_type          = A*;
   static A* f(A* const  & a,const A & b)  { *a += b; return a;}
 };
 
 template<class A>
-struct set_eq_sub: public binary_function<A*,A,A*> {
+struct set_eq_sub {
+  using first_argument_type  = A*;
+  using second_argument_type = A;
+  using result_type          = A*;
   static A* f(A* const  & a,const A & b)  { *a -= b; return a;}
 };
 
 template<class A,class B=A>
-struct set_eq_mul: public binary_function<A*,B,A*> {
+struct set_eq_mul {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a,const B & b)  { *a *= b; return a;}
 };
 
 template<class A,class B=A>
-struct set_eq_div: public binary_function<A*,B,A*> {
+struct set_eq_div {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a,const B & b)  { *a /= b; return a;}
 };
 
 
-struct set_peqstring: public binary_function<string**,string*,string**> {
+struct set_peqstring {
+  using first_argument_type  = string**;
+  using second_argument_type = string*;
+  using result_type          = string**;
   static string** f(string** const  & a, string * const & b)  {
     if(*a != b )
     { 
@@ -374,34 +503,52 @@ struct set_peqstring: public binary_function<string**,string*,string**> {
 
 //  ---------------------------------------------
 template<class A,class B>
-struct set_eqarrayp: public binary_function<A*,B,A*> {
+struct set_eqarrayp {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {  *a = *b; return a;}
 };
 
 template<class A,class B>
-struct set_eqarrayp_add: public binary_function<A*,B,A*> {
+struct set_eqarrayp_add {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  { assert(SameShape(*a,*b)); *a += *b; return a;}
 };
 
 template<class A,class B>
-struct set_eqarrayp_sub: public binary_function<A*,B,A*> {
+struct set_eqarrayp_sub {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  { assert(SameShape(*a,*b)); *a -= *b; return a;}
 };
 
 template<class A,class B>
-struct set_eqarrayp_mul: public binary_function<A*,B,A*> {
+struct set_eqarrayp_mul {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  { assert(SameShape(*a,*b)); *a *= *b; return a;}
 };
 
 
 template<class A,class B>
-struct set_eqarrayp_div: public binary_function<A*,B,A*> {
+struct set_eqarrayp_div {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  { assert(SameShape(*a,*b)); *a /= *b; return a;}
 };
 
 //  ---------------------------------------------
 template<class A,class B>
-struct set_eqarraypd: public binary_function<A*,B,A*> {
+struct set_eqarraypd {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,*b));  *a = *b;
    delete b;
    return a;}
@@ -409,28 +556,40 @@ struct set_eqarraypd: public binary_function<A*,B,A*> {
 
 
 template<class A,class B>
-struct set_eqarraypd_add: public binary_function<A*,B,A*> {
+struct set_eqarraypd_add {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,*b));  *a += *b; 
   delete b;
   return a;}
 };
 
 template<class A,class B>
-struct set_eqarraypd_sub: public binary_function<A*,B,A*> {
+struct set_eqarraypd_sub {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,*b));  *a -= *b; 
   delete b;
   return a;}
 };
 
 template<class A,class B>
-struct set_eqarraypd_mul: public binary_function<A*,B,A*> {
+struct set_eqarraypd_mul {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,*b));  *a *= *b;
    delete b;
    return a;}
 };
 
 template<class A,class B>
-struct set_eqarraypd_div: public binary_function<A*,B,A*> {
+struct set_eqarraypd_div {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,*b));  *a /= *b;
    delete b;
    return a;}
@@ -438,7 +597,10 @@ struct set_eqarraypd_div: public binary_function<A*,B,A*> {
 
 //  ---------------------------------------------
 template<class A,class B>
-struct set_eqarray: public binary_function<A*,B,A*> {
+struct set_eqarray {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  
   {  *a = b;
      return a;}
@@ -446,14 +608,17 @@ struct set_eqarray: public binary_function<A*,B,A*> {
 
 //  --------------------------------------------- august 2007 FH 
 template<class A,class B>
-struct init_eqarray: public binary_function<A*,B,A*> {
+struct init_eqarray {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
     static A* f(A* const  & a, B const & b)  
     {  a->init(); *a = b;
 	return a;}
 };
 /*
 template<class A,class B>
-struct init_eqarray_call: public binary_function<A*,B,A*> {
+struct init_eqarray_call {
     static A* f(A* const  & a, B const & b)
     {  a->init();
        b.call(*a);
@@ -461,7 +626,10 @@ struct init_eqarray_call: public binary_function<A*,B,A*> {
 };*/
 //  ---------------------------------------------
 template<class A,class B>
-struct init_eqarraypd: public binary_function<A*,B,A*> {
+struct init_eqarraypd {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
     static A* f(A* const  & a, B const & b)  {a->init();  *a = *b;
     delete b;
     return a;}
@@ -469,34 +637,52 @@ struct init_eqarraypd: public binary_function<A*,B,A*> {
 
 //  ---------------------------------------------
 template<class A,class B>
-struct init_eqarrayp: public binary_function<A*,B,A*> {
+struct init_eqarrayp {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
     static A* f(A* const  & a, B const & b)  {  a->init(); *a = *b; return a;}
 };
 
 // ----------------------------------------  fin modif august 2007
 
 template<class A,class B>
-struct set_eqarray_add: public binary_function<A*,B,A*> {
+struct set_eqarray_add {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,b));  *a += b; return a;}
 };
 
 template<class A,class B>
-struct set_eqarray_sub: public binary_function<A*,B,A*> {
+struct set_eqarray_sub {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,b));  *a -= b; return a;}
 };
 
 template<class A,class B>
-struct set_eqarray_mul: public binary_function<A*,B,A*> {
+struct set_eqarray_mul {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,b));  *a *= b; return a;}
 };
 
 template<class A,class B>
-struct set_eqarray_div: public binary_function<A*,B,A*> {
+struct set_eqarray_div {
+  using first_argument_type  = A*;
+  using second_argument_type = B;
+  using result_type          = A*;
   static A* f(A* const  & a, B const & b)  {assert(SameShape(*a,b));  *a /= b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_array: public binary_function<A,B,A> {
+struct set_eq_array{
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(const A & a, B const & b)  
   {  A aa=a;aa = b;
      return a;}
@@ -512,91 +698,139 @@ struct set_eq_array_call: public binary_function<A,B,A> {
 };
  */
 template<class A,class B>
-struct set_eq_array_add: public binary_function<A,B,A> {
+struct set_eq_array_add  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,b));  A aa(a);  aa += b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_array_sub: public binary_function<A,B,A> {
+struct set_eq_array_sub  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,b));  A aa(a);  aa -= b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_array_mul: public binary_function<A,B,A> {
+struct set_eq_array_mul  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,b));  A aa(a);  aa *= b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_array_div: public binary_function<A,B,A> {
+struct set_eq_array_div  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,b));  A aa(a);  aa /= b; return a;}
 };
 template<class A,class B>
-struct set_eq_arrayp: public binary_function<A,B,A> {
+struct set_eq_arrayp  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {  A aa(a);  aa = *b; return a;}
 };
 //  ---------------------------------------------
 template<class A,class B>
-struct set_eq_arraypd: public binary_function<A,B,A> {
+struct set_eq_arraypd  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,*b));A aa(a);  aa = *b;
   delete b;
   return a;}
 };
 
 template<class A,class B>
-struct set_eq_arrayp_sub: public binary_function<A,B,A> {
+struct set_eq_arrayp_sub  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  { assert(SameShape(a,*b));  A aa(a);  aa -= *b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_arrayp_mul: public binary_function<A,B,A> {
+struct set_eq_arrayp_mul  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  { assert(SameShape(a,*b));  A aa(a);  aa *= *b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_arrayp_div: public binary_function<A,B,A> {
+struct set_eq_arrayp_div  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  { assert(SameShape(a,*b));  A aa(a);  aa /= *b; return a;}
 };
 
 template<class A,class B>
-struct set_eq_arrayp_add: public binary_function<A,B,A> {
+struct set_eq_arrayp_add  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  { assert(SameShape(a,*b));  A aa(a);  aa += *b; return a;}
 };
 template<class A,class B>
-struct set_eq_arraypd_add: public binary_function<A,B,A> {
+struct set_eq_arraypd_add  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,*b)); A aa(a);  aa += *b;
    delete b;
    return a;}
 };
 template<class A,class B>
-struct set_eq_arraypd_sub: public binary_function<A,B,A> {
+struct set_eq_arraypd_sub  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,*b)); A aa(a);  aa -= *b;
    delete b;
    return a;}
 };
 
 template<class A,class B>
-struct set_eq_arraypd_mul: public binary_function<A,B,A> {
+struct set_eq_arraypd_mul  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,*b)); A aa(a);  aa *= *b;
    delete b;
    return a;}
 };
 
 template<class A,class B>
-struct set_eq_arraypd_div: public binary_function<A,B,A> {
+struct set_eq_arraypd_div  {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(A const  & a, B const & b)  {assert(SameShape(a,*b)); A aa(a);  aa /= *b;
    delete b;
    return a;}
 };
 
 template<class A>
-struct PrintP: public binary_function<ostream*,A,ostream*> {
+struct PrintP {
+  using first_argument_type  = ostream*;
+  using second_argument_type = A;
+  using result_type          = ostream*;
     static ostream* f(ostream* const  & a,const A & b)  {  if(b) *a << *b; 
 	// a->flush();// ADD FH MAi 2010 to empty the buffer  baf idea  add flush of ostream 
   //delete b; mars 2006 FH 
    return a;}
 };
 template<class A>
-struct PrintPnd: public binary_function<ostream*,A,ostream*> {
+struct PrintPnd {
+  using first_argument_type  = ostream*;
+  using second_argument_type = A;
+  using result_type          = ostream*;
   static ostream* f(ostream* const  & a,const A & b)  
     { if(verbosity>9999) cout << "PrintPnd:  " << b << endl;  *a << *b; return a;}
 };
@@ -664,72 +898,124 @@ template<class R,class A>  R * set_initp( R* const & a,const A & b){
     a->init(*b); return a;}
 
 template<class R,class A=R,class B=A> 
-struct Op2_add0: public binary_function<A,B,R> { 
+struct Op2_add0 {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return (a + b);} };  
 
 template<class R,class A=R,class B=A> 
-struct Op2_build: public binary_function<A,B,R> { 
+struct Op2_build {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return R(a,b);} };  
 template<class R,class A=R,class B=A> 
 
-struct Op2_pbuild: public binary_function<A,B,R*> { 
+struct Op2_pbuild {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R *f(const A & a,const B & b)  { return new R(a,b);} };  
   
 template<class R,class A=R,class B=A> 
-struct Op2_add__n: public binary_function<A,B,R*> { 
+struct Op2_add__n {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R * f(const A & a,const B & b)  { return new R(a + b);} };    
 template<class R,class A=R,class B=A> 
-struct Op2_addp_n: public binary_function<A,B,R*> { 
+struct Op2_addp_n {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R* f(const A & a,const B & b)  { return new R(*a + b);} };   
 template<class R,class A=R,class B=A> 
-struct Op2_add_pn: public binary_function<A,B,R*> { 
+struct Op2_add_pn {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R* f(const A & a,const B & b)  { return new R(a + *b);} };   
 
 
 template<class R,class A=R,class B=A> 
-struct Op2_sub0: public binary_function<A,B,R> { 
+struct Op2_sub0 {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return (a - b);} }; 
   
 template<class R,class A=R> 
-struct Op1_subp: public unary_function<A,R> { 
+struct Op1_subp{
+  using argument_type  = A;
+  using result_type    = R;
   static R f(const A & a)  { return (- *a );} };   
 template<class R,class A=R> 
-struct Op1_sub: public unary_function<A,R> { 
+struct Op1_sub{
+  using argument_type  = A;
+  using result_type    = R;
 static R f(const A & a)  { return (- a );} };   
 
 template<class R,class A=R,class B=A> 
-struct Op2_mulcp: public binary_function<A,B,R> { 
+struct Op2_mulcp {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return (a * *b);} }; 
 
 template<class R,class A=R,class B=A> 
-struct Op2_mulc: public binary_function<A,B,R> { 
+struct Op2_mulc {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return (a * b);} };
 
 template<class R,class A=R,class B=A>
-struct Op2_divc: public binary_function<A,B,R> {
+struct Op2_divc {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
     static R f(const A & a,const B & b)  { return (a / b);} };
 
 template<class R,class A=R,class B=A> 
-struct Op2_mulpc: public binary_function<A,B,R> { 
+struct Op2_mulpc {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return (b * *a);} }; 
 
 template<class R,class A=R,class B=A> 
-struct Op2_mulpcp: public binary_function<A,B,R> {
+struct Op2_mulpcp {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
   static R f(const A & a,const B & b)  { return (*a * *b);} };
 
 template<class R,class A=R,class B=A>
-struct Op2_2p_: public binary_function<A,B,R> {
+struct Op2_2p_ {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R;
     static R f(const A & a,const B & b)  { return R(*a,*b);} };
 
 
 template<class R,class A=R,class B=A> 
-struct Op2_sub__n: public binary_function<A,B,R*> { 
+struct Op2_sub__n {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R * f(const A & a,const B & b)  { return new R(a - b);} };    
 template<class R,class A=R,class B=A> 
-struct Op2_subp_n: public binary_function<A,B,R*> { 
+struct Op2_subp_n {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R* f(const A & a,const B & b)  { return new R(*a - b);} };   
 template<class R,class A=R,class B=A> 
-struct Op2_sub_pn: public binary_function<A,B,R*> { 
+struct Op2_sub_pn {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R* f(const A & a,const B & b)  { return new R(a - *b);} };   
 
 
@@ -738,7 +1024,10 @@ struct Op3_p: public ternary_function<A,B,C,R*> {
   static R* f(Stack s,const A & a,const B & b,const  C & c )  { return new R(a,b,c);} };   
 
 template<class R,class A=R,class B=A> 
-struct Op2_p: public binary_function<A,B,R*> { 
+struct Op2_p {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = R*;
   static R* f(const A & a,const B & b)  { return new R(a,b);} };   
 
 

--- a/src/fflib/String.hpp
+++ b/src/fflib/String.hpp
@@ -192,8 +192,11 @@ public:
     
 };
 template<class A,class B>
-struct pairless : binary_function<pair<A,B>,const char *, bool>
+struct pairless
    { 
+    using first_argument_type  = pair<A,B>;
+    using second_argument_type = const char *;
+    using result_type          = bool;
     typedef pair<A,B> Key;
     bool operator()(const Key& x, const Key& y) const { return  x.first<y.first ? true
        :  (  (x.first == y.first)  ? (x.second < y.second) : false );} };

--- a/src/fflib/array_long.cpp
+++ b/src/fflib/array_long.cpp
@@ -92,7 +92,10 @@ template<class A> inline AnyType Destroy_KN(Stack,const AnyType &x) {
 // end add
 
 template<class A,class B>
-struct set_Inv_KN_long : public binary_function<A,B,A> {
+struct set_Inv_KN_long {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(const A & a, B const & b) {
     int n = a.N();
     KN_<long> I(b.t);
@@ -106,7 +109,10 @@ struct set_Inv_KN_long : public binary_function<A,B,A> {
 };
 
 template<class A,class B>
-struct set_Inv_pKN_longI: public binary_function<A,B,A> {
+struct set_Inv_pKN_longI {
+  using first_argument_type  = A;
+  using second_argument_type = B;
+  using result_type          = A;
   static A f(const A & a, B const & b) {
     KN_<long> I(b.t);
     int n = I.max() + 1;

--- a/src/fflib/array_tlp.hpp
+++ b/src/fflib/array_tlp.hpp
@@ -60,20 +60,29 @@ namespace Fem2D {
 #include "R3.hpp"
 }
 template <class T>
-struct affectation: binary_function<T, T, T>
+struct affectation
 {
+	using first_argument_type  = T;
+	using second_argument_type = T;
+	using result_type          = T;
 	T& operator()(T& x, const T& y) const {return (x=y);}
 };
 
 template <class T>
-struct affectation_add: binary_function<T, T, T>
+struct affectation_add
 {
+	using first_argument_type  = T;
+	using second_argument_type = T;
+	using result_type          = T;
 	T& operator()(T& x, const T& y) const {return (x+=y);}// correct FH 25/10/2013
 };
 
 template <class T>
-struct affectation_sub: binary_function<T, T, T>
+struct affectation_sub
 {
+	using first_argument_type  = T;
+	using second_argument_type = T;
+	using result_type          = T;
 	T& operator()(T& x, const T& y) const {return (x-=y);}// correct FH 25/10/2013
 };
 
@@ -92,12 +101,18 @@ template<class T> inline T Square (const T &a){return a*a;}
 
 
 template<class K>
-struct Op2_dotproduct: public binary_function<Transpose<KN_<K> >,KN<K> *,K> {
+struct Op2_dotproduct {
+  using first_argument_type  = Transpose<KN_<K> >;
+  using second_argument_type = KN<K> *;
+  using result_type          = K;
   static K f( Transpose<KN_<K> > const & a, KN<K> * const& b)
    { return (conj(a.t),*b);} };
 
 template<class K>
-struct Op2_dotproduct_: public binary_function<Transpose<KN_<K> >,KN_<K> ,K> {
+struct Op2_dotproduct_ {
+  using first_argument_type  = Transpose<KN_<K> >;
+  using second_argument_type = KN_<K>;
+  using result_type          = K;
   static K f( Transpose<KN_<K> > const & a, KN_<K>  const& b)
    { return (conj(a.t),b);} };
 
@@ -961,7 +976,10 @@ template<class A,class B> pair<A,B> * pBuild(const A & a,const B & b)
 
 // add mars 2006
 template<class K,class L,class OP>
-struct set_A_BI: public binary_function<KN_<K>,pair<KN_<K>, KN_<L> > *,KN_<K> > {
+struct set_A_BI {
+  using first_argument_type  = KN_<K>;
+  using second_argument_type = pair<KN_<K>, KN_<L> > *;
+  using result_type          = KN_<K>;
   static KN_<K> f(const KN_<K>   & a, pair<KN_<K>, KN_<L> > * const & b)  {
     KN_<K> x(a);
     OP op;
@@ -989,7 +1007,10 @@ struct set_A_BI: public binary_function<KN_<K>,pair<KN_<K>, KN_<L> > *,KN_<K> > 
 };
 //  add oct 2019  To:  real[int] b = a(I); // where a and I is also a array..
 template<class K,class L,class OP>
-struct init_A_BI: public binary_function<KN<K>* ,pair<KN_<K>, KN_<L> > *,KN<K>* > {
+struct init_A_BI {
+  using first_argument_type  = KN<K>*;
+  using second_argument_type = pair<KN_<K>, KN_<L> > *;
+  using result_type          = KN<K>*;
     static KN<K>* f( KN<K>  * const  & a, pair<KN_<K>, KN_<L> > * const & b)  {
         KN<K> * px(a);
         OP op;
@@ -1018,7 +1039,10 @@ struct init_A_BI: public binary_function<KN<K>* ,pair<KN_<K>, KN_<L> > *,KN<K>* 
     }
 };
 template<class K,class L,class OP>
-struct set_AI_B: public binary_function<pair<KN_<K>, KN_<L> > * ,KN_<K>, NothingType > {
+struct set_AI_B {
+  using first_argument_type  = pair<KN_<K>, KN_<L> > *;
+  using second_argument_type = KN_<K>;
+  using result_type          = NothingType;
   static NothingType  f( pair<KN_<K>, KN_<L> > * const & b,const KN_<K>   & a)  {
     KN_<K> x(a);
     OP op;
@@ -1070,7 +1094,10 @@ struct Op3_pacc: public ternary_function<KN_<K>,K,K,if_arth_KN_<K>*> {
 };
 template<class K> KNM_<K> Transp(KNM_<K>  M){ return M.t();} // Add FH July 2015
 template<class K>
-struct SetArray2: public binary_function<K,K,SetArray<K> > {
+struct SetArray2{
+  using first_argument_type  = K;
+  using second_argument_type = K;
+  using result_type          = SetArray<K>;
   static SetArray<K> f(const K & a,const K & b)  {
     // cout << "SubArray: " << a << " " << b << endl;
     //     SetArray(long nn,R oo=R(),R sstep=R(1)): o(oo),n(nn),step(sstep) {}

--- a/src/fflib/glumesh2D.cpp
+++ b/src/fflib/glumesh2D.cpp
@@ -190,13 +190,19 @@ Mesh * GluMesh(list<Mesh const *> const & lth, long labtodel = -1,double eps=-1)
 }
 
 template<class RR,class AA=RR,class BB=AA>
-struct Op2_addmesh: public binary_function<AA,BB,RR> {
+struct Op2_addmesh {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(Stack s,const AA & a,const BB & b)
   { return RR(s, a, b );}
 };
 
 template<bool INIT,class RR,class AA=RR,class BB=AA>
-struct Op2_setmesh: public binary_function<AA,BB,RR> {
+struct Op2_setmesh {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(Stack stack, const AA & a,const BB & b)
   {
     ffassert(a );

--- a/src/fflib/lex.hpp
+++ b/src/fflib/lex.hpp
@@ -45,8 +45,12 @@ class mylex : public CodeAlloc {
    struct MacroData{ deque<string> d; int l; string f;};// f is not a pointeur (pb of delete) 
     //   Warning  f not a pointeur because
     //
-  struct Keyless : binary_function<Key,Key, bool>
-   { bool operator()(const Key& x, const Key& y) const{ return strcmp(x,y)<0;} };  
+  struct Keyless
+   {
+    using first_argument_type  = Key;
+    using second_argument_type = Key;
+    using result_type          = bool;
+    bool operator()(const Key& x, const Key& y) const{ return strcmp(x,y)<0;} };
   typedef   map<const char *,Value,Keyless> MapMotClef;
   typedef   map<const char *,MacroData ,Keyless >  MapMacroDef;
   typedef   map<string, string  >  MapMacroParam;

--- a/src/fflib/lgfem.cpp
+++ b/src/fflib/lgfem.cpp
@@ -3168,8 +3168,10 @@ LinkToInterpreter::LinkToInterpreter( ) {
 }
 
 template< class K >
-struct set_eqmatrice_creuse_fbl
-  : public binary_function< Matrice_Creuse< K > *, const Matrice_Creuse< K > *, const C_args * > {
+struct set_eqmatrice_creuse_fbl {
+   using first_argument_type  = Matrice_Creuse< K > *;
+   using second_argument_type = const Matrice_Creuse< K > *;
+   using result_type          = const C_args *;
   static Matrice_Creuse< K > *f(Matrice_Creuse< K > *const &a, const C_args *const &b) {
     // 1  verif the FESpace
 
@@ -3181,7 +3183,10 @@ struct set_eqmatrice_creuse_fbl
 };
 
 template< class K >
-struct set_eqvect_fl : public binary_function< KN< K > *, const FormLinear *, KN< K > * > {
+struct set_eqvect_fl {
+   using first_argument_type  = KN< K > *;
+   using second_argument_type = const FormLinear *;
+   using result_type          = KN< K > *;
   static KN< K > *f(KN< K > *const &a, const FormLinear *const &b) {
     ffassert(0);
     return a;
@@ -5753,19 +5758,28 @@ template<  class A >
             OneOperator_trans_Ptr_o_R(ptr pp) : OneOperator(atype< Result * >( ), atype< Transpose<A *> >( )), p(pp) {}
         };
 template <class R,class A, class B> 
-struct OppR3dot: public binary_function<A,B,R> {
+struct OppR3dot {
+   using first_argument_type  = A;
+   using second_argument_type = B;
+   using result_type          = R;
   static R f(const A & a,const B & b)  {
       B pu = a;
       return (*pu,*b);} };
 
 template <class R,class A, class B>
-struct OppqR3dot: public binary_function<A,B,R> {
+struct OppqR3dot {
+   using first_argument_type  = A;
+   using second_argument_type = B;
+   using result_type          = R;
   static R f(const A & a,const B & b)  {
       B* pu = a;
       return (*pu,b);} };
 
 template <class R,class A, class B>
-struct OpR3dot: public binary_function<A,B,R> {
+struct OpR3dot {
+   using first_argument_type  = A;
+   using second_argument_type = B;
+   using result_type          = R;
   static R f(const A & a,const B & b)  {
       B pu = a;
       return (pu,b);} };

--- a/src/fflib/lgmat.cpp
+++ b/src/fflib/lgmat.cpp
@@ -90,8 +90,11 @@ AnyType tM2L3 (Stack , const AnyType & pp)
 
 
 template<class R>
-struct Op2_ListCM: public binary_function<R,Matrice_Creuse<R> *,list<tuple<R,MatriceCreuse<R> *,bool> > *>
+struct Op2_ListCM
  {
+   using first_argument_type  = R;
+   using second_argument_type = Matrice_Creuse<R> *;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
    typedef tuple<R,MatriceCreuse<R> *,bool>  P;
    typedef list<P> L;
    typedef L * RR;
@@ -130,8 +133,11 @@ template<class R> void PrintL(const char* cc, list<tuple<R,VirtualMatrix<int,R>*
     cout << ") "<< endl;
 }
 template<class R>
-struct Op2_ListMC: public binary_function<Matrice_Creuse<R> *,R,list<tuple<R,MatriceCreuse<R> *,bool> > *>
+struct Op2_ListMC
  {
+   using first_argument_type  = Matrice_Creuse<R> *;
+   using second_argument_type = R;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
    typedef tuple<R,MatriceCreuse<R> *,bool>  P;
    typedef list<P> L;
    typedef L * RR;
@@ -148,8 +154,11 @@ struct Op2_ListMC: public binary_function<Matrice_Creuse<R> *,R,list<tuple<R,Mat
 //  ADD FH 16/02/2007
 
 template<class R>
-struct Op2_ListCMt: public binary_function<R,Matrice_Creuse_Transpose<R> ,list<tuple<R,MatriceCreuse<R> *,bool> > *>
+struct Op2_ListCMt
 {
+   using first_argument_type  = R;
+   using second_argument_type = Matrice_Creuse_Transpose<R> ;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
     typedef tuple<R,MatriceCreuse<R> *,bool>  P;
     typedef list<P> L;
     typedef L * RR;
@@ -165,8 +174,11 @@ struct Op2_ListCMt: public binary_function<R,Matrice_Creuse_Transpose<R> ,list<t
 };
 
 template<class R>
-struct Op2_ListMtC: public binary_function<Matrice_Creuse_Transpose<R> ,R,list<tuple<R,MatriceCreuse<R> *,bool> > *>
+struct Op2_ListMtC
 {
+   using first_argument_type  = Matrice_Creuse_Transpose<R> ;
+   using second_argument_type = R;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
     typedef tuple<R,MatriceCreuse<R> *,bool>  P;
     typedef list<P> L;
     typedef L * RR;
@@ -185,9 +197,10 @@ struct Op2_ListMtC: public binary_function<Matrice_Creuse_Transpose<R> ,R,list<t
 
 
 template<class R,int c=-1>
-struct Op1_LCMd: public unary_function<list<tuple<R,MatriceCreuse<R> *,bool> > *,
-list<tuple<R,MatriceCreuse<R> *,bool> > *  >
+struct Op1_LCMd
 {  //  - ...
+  using argument_type  = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+  using result_type    = list<tuple<R,MatriceCreuse<R> *,bool> > *;
     typedef tuple<R,MatriceCreuse<R> *,bool>  P;
     typedef list<P> L;
     typedef L * RR;
@@ -204,10 +217,11 @@ list<tuple<R,MatriceCreuse<R> *,bool> > *  >
 };
 
 template<class R>
-struct Op2_ListCMCMadd: public binary_function<list<tuple<R,MatriceCreuse<R> *,bool> > *,
-                                               list<tuple<R,MatriceCreuse<R> *,bool> > *,
-                                               list<tuple<R,MatriceCreuse<R> *,bool> > *  >
+struct Op2_ListCMCMadd
 {  //  ... + ...
+   using first_argument_type  = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+   using second_argument_type = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
    typedef tuple<R,MatriceCreuse<R> *,bool>  P;
    typedef list<P> L;
    typedef L * RR;
@@ -222,10 +236,11 @@ struct Op2_ListCMCMadd: public binary_function<list<tuple<R,MatriceCreuse<R> *,b
 
 };
 template<class R>
-struct Op2_ListCMCMsub: public binary_function<list<tuple<R,MatriceCreuse<R> *,bool> > *,
-list<tuple<R,MatriceCreuse<R> *,bool> > *,
-list<tuple<R,MatriceCreuse<R> *,bool> > *  >
+struct Op2_ListCMCMsub
 {  //  ... + ...
+   using first_argument_type  = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+   using second_argument_type = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
     typedef tuple<R,MatriceCreuse<R> *,bool>  P;
     typedef list<P> L;
     typedef L * RR;
@@ -245,10 +260,11 @@ list<tuple<R,MatriceCreuse<R> *,bool> > *  >
 };
 
 template<class R,int cc=1>
-struct Op2_ListMCMadd: public binary_function<Matrice_Creuse<R> *,
-                                              list<tuple<R,MatriceCreuse<R> *,bool> > *,
-                                               list<tuple<R,MatriceCreuse<R> *,bool> > *  >
+struct Op2_ListMCMadd
 {  //  M + ....
+   using first_argument_type  = Matrice_Creuse<R> *;
+   using second_argument_type = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
    typedef tuple<R,MatriceCreuse<R> *,bool> P;
    typedef list<P> L;
    typedef L * RR;
@@ -268,10 +284,11 @@ struct Op2_ListMCMadd: public binary_function<Matrice_Creuse<R> *,
 };
 
 template<class R,int cc=1>
-struct Op2_ListCMMadd: public binary_function< list<tuple<R,MatriceCreuse<R> *,bool> > *,
-                                               Matrice_Creuse<R> * ,
-                                               list<tuple<R,MatriceCreuse<R> *,bool> > *>
+struct Op2_ListCMMadd
 {  //   .... + M
+   using first_argument_type  = list<tuple<R,MatriceCreuse<R> *,bool> > *;
+   using second_argument_type = Matrice_Creuse<R> *;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
    typedef tuple<R,MatriceCreuse<R> *,bool> P;
    typedef list<P> L;
    typedef L * RR;
@@ -288,10 +305,11 @@ struct Op2_ListCMMadd: public binary_function< list<tuple<R,MatriceCreuse<R> *,b
 };
 
 template<class R,int cc=1>
-struct Op2_ListMMadd: public binary_function< Matrice_Creuse<R> *,
-                                              Matrice_Creuse<R> * ,
-                                              list<tuple<R,MatriceCreuse<R> *,bool> > *>
+struct Op2_ListMMadd
 {  //  M + M
+   using first_argument_type  = Matrice_Creuse<R> *;
+   using second_argument_type = Matrice_Creuse<R> *;
+   using result_type          = list<tuple<R,MatriceCreuse<R> *,bool> > *;
    typedef tuple<R,MatriceCreuse<R> *,bool> P;
    typedef list<P> L;
    typedef L * RR;
@@ -1794,7 +1812,10 @@ AnyType MatFull2Sparse(Stack stack,Expression emat,Expression eA)
 }
 
 template<class RR,class AA=RR,class BB=AA>
-struct Op2_pair: public binary_function<AA,BB,RR> {
+struct Op2_pair {
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(const AA & a,const BB & b)
   { return RR( a, b);}
 };
@@ -1898,13 +1919,19 @@ R  get_element2mc(Matrice_Creuse<R> * const  & ac,const long & b,const long & c)
     return  r;}
 
 template<class RR,class AA=RR,class BB=AA>
-struct Op2_mulAv: public binary_function<AA,BB,RR> {
+struct Op2_mulAv{
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(const AA & a,const BB & b)
   { return (*a->A * *b );}
 };
 
 template<class RR,class AA=RR,class BB=AA>
-struct Op2_mulvirtAv: public binary_function<AA,BB,RR> {
+struct Op2_mulvirtAv{
+   using first_argument_type  = AA;
+   using second_argument_type = BB;
+   using result_type          = RR;
   static RR f(const AA & a,const BB & b)
   { return RR( (*a).A, b );}
 };

--- a/src/fflib/string_def.cpp
+++ b/src/fflib/string_def.cpp
@@ -76,7 +76,10 @@ string **get_replace(string **pp, long i, long j, string *rr) {
 }
 // a( : ) = "sqsd";
 
-struct set_substring : public binary_function<SubString, string *, SubString> {
+struct set_substring {
+   using first_argument_type  = SubString;
+   using second_argument_type = string *;
+   using result_type          = SubString;
 
   static SubString f(SubString const &a, string *const &b) {
     string s = *a.s;

--- a/src/mpi/parallelempi.cpp
+++ b/src/mpi/parallelempi.cpp
@@ -1052,7 +1052,10 @@ Serialize::Serialize(const MPIrank & rank,const char * wht,long tag,const void *
 }
 
 template<class A>
-struct Op_Readmpi : public binary_function<MPIrank,A*,MPIrank> {
+struct Op_Readmpi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A*;
+  using result_type          = MPIrank;
   static MPIrank  f(MPIrank const  & f,A *  const  & a)
   {
     f.Recv(*a);
@@ -1061,7 +1064,10 @@ struct Op_Readmpi : public binary_function<MPIrank,A*,MPIrank> {
 };
 
 template<class A>
-struct Op_Recvmpi : public binary_function<MPIrank,A*,long> {
+struct Op_Recvmpi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A*;
+  using result_type          = long;
   static MPIrank  f(MPIrank const  & f,A *  const  & a)
   {
     ffassert(f.rq ==0 || f.rq == Syncro_block); // Block
@@ -1070,7 +1076,10 @@ struct Op_Recvmpi : public binary_function<MPIrank,A*,long> {
   }
 };
 template<class A>
-struct Op_IRecvmpi : public binary_function<MPIrank,A*,long> {
+struct Op_IRecvmpi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A*;
+  using result_type          = long;
   static MPIrank  f(MPIrank const  & f,A *  const  & a)
   {
     ffassert(f.rq !=0 || f.rq != Syncro_block); // no Block
@@ -1081,7 +1090,10 @@ struct Op_IRecvmpi : public binary_function<MPIrank,A*,long> {
 
 
 template<class A>
-struct Op_Writempi : public binary_function<MPIrank,A,MPIrank> {
+struct Op_Writempi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A;
+  using result_type          = MPIrank;
   static MPIrank  f(MPIrank const  & f,A   const  &  a)
   {
     f.Send(a);
@@ -1091,7 +1103,10 @@ struct Op_Writempi : public binary_function<MPIrank,A,MPIrank> {
 
 
 template<class A>
-struct Op_Bcastmpi : public binary_function<MPIrank,A*,MPIrank> {
+struct Op_Bcastmpi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A*;
+  using result_type          = MPIrank;
   static MPIrank  f(MPIrank const  & f,A *  const  & a)
   {
     f.Bcast(*a);
@@ -1100,7 +1115,10 @@ struct Op_Bcastmpi : public binary_function<MPIrank,A*,MPIrank> {
 };
 
 template<class A>
-struct Op_ISendmpi : public binary_function<MPIrank,A,long> {
+struct Op_ISendmpi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A;
+  using result_type          = long;
   static MPIrank  f(MPIrank const  & f,A   const  & a)
   {
     ffassert(f.rq != Syncro_block);
@@ -1108,7 +1126,10 @@ struct Op_ISendmpi : public binary_function<MPIrank,A,long> {
   }
 };
 template<class A>
-struct Op_Sendmpi : public binary_function<MPIrank,A,long> {
+struct Op_Sendmpi {
+  using first_argument_type  = MPIrank;
+  using second_argument_type = A;
+  using result_type          = long;
   static MPIrank  f(MPIrank const  & f,A  const  & a)
   {
 	MPIrank ff(f.who,f.comm,Syncro_block);
@@ -1118,7 +1139,10 @@ struct Op_Sendmpi : public binary_function<MPIrank,A,long> {
 
 
 template<class R>
-struct Op_All2All : public binary_function<KN_<R>,KN_<R>,long> {
+struct Op_All2All {
+  using first_argument_type  = KN_<R>;
+  using second_argument_type = KN_<R>;
+  using result_type          = long;
   static long  f( KN_<R>  const  & s, KN_<R>  const  &r)
   {
       CheckContigueKN(s);
@@ -1137,7 +1161,10 @@ struct Op_All2All : public binary_function<KN_<R>,KN_<R>,long> {
 
 
 template<class R>
-struct Op_Allgather1 : public binary_function<R*,KN_<R>,long> {
+struct Op_Allgather1 {
+  using first_argument_type  = R*;
+  using second_argument_type = KN_<R>;
+  using result_type          = long;
   static long  f( R*  const  & s, KN_<R>  const  &r)
     {
       MPI_Comm comm=MPI_COMM_WORLD;
@@ -1154,7 +1181,10 @@ struct Op_Allgather1 : public binary_function<R*,KN_<R>,long> {
 };
 
 template<class R>
-struct Op_Allgather : public binary_function<KN_<R>,KN_<R>,long> {
+struct Op_Allgather {
+  using first_argument_type  = KN_<R>;
+  using second_argument_type = KN_<R>;
+  using result_type          = long;
   static long  f( KN_<R>  const  & s, KN_<R>  const  &r)
     {
 	CheckContigueKN(s);
@@ -1682,7 +1712,10 @@ long  Op_Gatherv3(KN_<R>  const  & s, KN_<R>  const  &r,  MPIrank const & root, 
 // Add J. Morice communications entre processeurs complex
 
 template<>
-struct Op_All2All<Complex> : public binary_function<KN_<Complex>,KN_<Complex>,long> {
+struct Op_All2All<Complex> {
+  using first_argument_type  = KN_<Complex>;
+  using second_argument_type = KN_<Complex>;
+  using result_type          = long;
   static long  f( KN_<Complex>  const  & s, KN_<Complex>  const  &r)
   {
       CheckContigueKN(r);
@@ -1706,7 +1739,10 @@ struct Op_All2All<Complex> : public binary_function<KN_<Complex>,KN_<Complex>,lo
 };
 
 template<>
-struct Op_Allgather1<Complex> : public binary_function<Complex *,KN_<Complex>,long> {
+struct Op_Allgather1<Complex> {
+  using first_argument_type  = Complex*;
+  using second_argument_type = KN_<Complex>;
+  using result_type          = long;
   static long  f( Complex *  const  & s, KN_<Complex>  const  &r)
   {
       CheckContigueKN(r);
@@ -1730,7 +1766,10 @@ struct Op_Allgather1<Complex> : public binary_function<Complex *,KN_<Complex>,lo
 
 
 template<>
-struct Op_Allgather<Complex> : public binary_function<KN_<Complex>,KN_<Complex>,long> {
+struct Op_Allgather<Complex> {
+  using first_argument_type  = KN_<Complex>;
+  using second_argument_type = KN_<Complex>;
+  using result_type          = long;
   static long  f( KN_<Complex>  const  & s, KN_<Complex>  const  &r)
     {
 	CheckContigueKN(r);


### PR DESCRIPTION
The unary_function and binary_function are deprecated since C++11 and removed in C++17 according to https://en.cppreference.com/w/cpp/utility/functional/unary_function

Building with gcc 12 triggers lots of warnings on stderr when building Debian package auto-tests: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1033702

This Pull Request removes these functions and adds the appropriate `using` to keep compatibility.