### PR TITLE
Fix binary spelling errors.

### DIFF
--- a/plugin/seq/plotPDF.cpp
+++ b/plugin/seq/plotPDF.cpp
@@ -3457,9 +3457,9 @@ void plot_vector2flow( std::stringstream &Content, const Fem2D::Mesh &Th,
 	(fmax - fmin)/nbfill;
 
     if( varrow )
-	std::cout << "plotPDF(): Option 'varrow' is not implmeneted yet." << endl;
+	std::cout << "plotPDF(): Option 'varrow' is not implemented yet." << endl;
     if( nbarrow != 0 )
-	std::cout << "plotPDF(): Option 'nbarrow' is not implmeneted yet." << endl;
+	std::cout << "plotPDF(): Option 'nbarrow' is not implemented yet." << endl;
 
     std::stringstream &st = Content;
     st.str("");

--- a/src/Graphics/Pcrgraph.cpp
+++ b/src/Graphics/Pcrgraph.cpp
@@ -909,7 +909,7 @@ void openSVG(const char *filename )
   }
   else
   {
-    cerr << " Err openning SVG file " << fsvg << endl;
+    cerr << " Err opening SVG file " << fsvg << endl;
   }
   return;
 }

--- a/src/Graphics/Xrgraph.cpp
+++ b/src/Graphics/Xrgraph.cpp
@@ -1291,7 +1291,7 @@ void openSVG(const char *filename )
   }
   else
   {
-    cerr << " Err openning SVG file " << fsvg << endl;
+    cerr << " Err opening SVG file " << fsvg << endl;
   }
   return;
 }

--- a/src/Graphics/glrgraph.hpp
+++ b/src/Graphics/glrgraph.hpp
@@ -1718,7 +1718,7 @@ void openSVG(const char *filename )
   }
   else
   {
-    cerr << " Err openning SVG file " << fsvg << endl;
+    cerr << " Err opening SVG file " << fsvg << endl;
   }
   return;
 }

--- a/src/Graphics/macrgraf.cpp
+++ b/src/Graphics/macrgraf.cpp
@@ -1268,7 +1268,7 @@ void openSVG(const char *filename )
   }
   else
   {
-    cerr << " Err openning SVG file " << fsvg << endl;
+    cerr << " Err opening SVG file " << fsvg << endl;
   }
   return;
 }

--- a/src/Graphics/sansrgraph.cpp
+++ b/src/Graphics/sansrgraph.cpp
@@ -751,7 +751,7 @@ void openSVG(const char *filename )
   }
   else
   {
-    cerr << " Err openning SVG file " << fsvg << endl;
+    cerr << " Err opening SVG file " << fsvg << endl;
   }
   return;
 }

--- a/src/femlib/VirtualSolverSparseSuite.hpp
+++ b/src/femlib/VirtualSolverSparseSuite.hpp
@@ -59,7 +59,7 @@ inline void CheckUmfpackStatus(int status)
                     break;
 
                 default:
-                    cout << status<< " UMFPACK WARNING unknow" <<endl;
+                    cout << status<< " UMFPACK WARNING unknown" <<endl;
                     break;
             }
         
@@ -97,7 +97,7 @@ inline void CheckUmfpackStatus(int status)
                 break;
 
             default:
-                ferr << status<< "  unknow error (SEE umfpack) file" <<endl;
+                ferr << status<< "  unknown error (SEE umfpack) file" <<endl;
                 break;
         }
         ferr << ends;


### PR DESCRIPTION
Fix spelling errors in the generated binary files:

- implmeneted > implemented
- openning > opening
- unknow > unknown

The Debian automatic check also detects "Nam" instead of "Name" in `IncompleteCholesky.so` but I wasn't able to spot the source. Do not hesitated to edit if appropriate.

Best,
François

