### PR TITLE
Access TSConvergedReason with TSSolve plugin

### DIFF
--- a/plugin/mpi/PETSc-code.hpp
+++ b/plugin/mpi/PETSc-code.hpp
@@ -4675,6 +4675,12 @@ namespace PETSc {
           SNESSetKSP(snes, ksp);
           KSPDestroy(&ksp);
         }
+        if(nargs[11]) {
+          TSConvergedReason reason;
+          TSGetConvergedReason(ts, &reason);
+          long* ret = GetAny< long* >((*nargs[11])(stack));
+          *ret = static_cast<long>(reason);
+        }
         TSDestroy(&ts);
         delete user->mon;
         delete user->r;


### PR DESCRIPTION
This commit doesn't produce any errors, but it also doesn't finish the job... Something is still missing. Any ideas? My goal is to get TSConvergedReason with
```
int ret;
TSSolve(..., reason = ret, ...);
```