### PR TITLE
Eliminate unneeded error in `gmsh.cpp`

### DIFF
--- a/plugin/seq/gmsh.cpp
+++ b/plugin/seq/gmsh.cpp
@@ -433,11 +433,6 @@ Mesh *GMSH_Load(const string &filename) {
                 cout << "mes=" << tff[it].area << endl;
               }
 
-              if (tff[it].area < 1e-8) {
-                cerr << "bug : mes < 1e-8 !" << endl;
-                exit(1);
-              }
-
               it++;
             }
           }


### PR DESCRIPTION
gmsh plugin throws an error when area is below an arbitrary threshold.