### PR TITLE
Change all mesh variables to double precision (`Real4` -> `Real8`)

### DIFF
--- a/src/bamglib/Mesh2.cpp
+++ b/src/bamglib/Mesh2.cpp
@@ -2435,7 +2435,7 @@ namespace bamg {
     quadtree->Add(*v0);
     quadtree->Add(*v1);
 
-    // on ajoute les sommets un � un
+    // on ajoute les sommets un à un
     Int4 NbSwap = 0;
 
     time1 = CPUtime( );
@@ -2594,7 +2594,7 @@ namespace bamg {
             Triangle *tc = HeapTriangle[i];    // triangle courant
             if (!tc->Locked(na))               // arete non frontiere
             {
-              Triangle *ta = tc->TriangleAdj(na);    // n� triangle adjacent
+              Triangle *ta = tc->TriangleAdj(na);    // n° triangle adjacent
               if (ta->link == 0)                     // non deja chainer => on enpile
               {
                 i++;

--- a/src/bamglib/Mesh2.cpp
+++ b/src/bamglib/Mesh2.cpp
@@ -731,7 +731,7 @@ namespace bamg {
       } else {    // next triangle by  adjacent by edge ocut
         deti = dt[i];
         detj = dt[j];
-        Real4 dij = detj - deti;
+        Real8 dij = detj - deti;
         ba[i] = detj / dij;
         ba[j] = -deti / dij;
         ba[3 - i - j] = 0;
@@ -1709,7 +1709,7 @@ namespace bamg {
         Vertex &vi = *ordre[i];
         vi.i = toI2(vi.r);
         vi.r = toR2(vi.i);
-        Real4 hx, hy;
+        Real8 hx, hy;
         vi.m.Box(hx, hy);
         Icoor1 hi = (Icoor1)(hx * coefIcoor), hj = (Icoor1)(hy * coefIcoor);
         if (!quadtree->ToClose(vi, seuil, hi, hj)) {
@@ -2435,7 +2435,7 @@ namespace bamg {
     quadtree->Add(*v0);
     quadtree->Add(*v1);
 
-    // on ajoute les sommets un Ò un
+    // on ajoute les sommets un ï¿½ un
     Int4 NbSwap = 0;
 
     time1 = CPUtime( );
@@ -2594,7 +2594,7 @@ namespace bamg {
             Triangle *tc = HeapTriangle[i];    // triangle courant
             if (!tc->Locked(na))               // arete non frontiere
             {
-              Triangle *ta = tc->TriangleAdj(na);    // næ triangle adjacent
+              Triangle *ta = tc->TriangleAdj(na);    // nï¿½ triangle adjacent
               if (ta->link == 0)                     // non deja chainer => on enpile
               {
                 i++;

--- a/src/bamglib/Mesh2.h
+++ b/src/bamglib/Mesh2.h
@@ -77,7 +77,7 @@ int myrand(void);
 
   typedef P2< Real8, Real8 > R2;
   typedef P2xP2< Int2, Int4 > I2xI2;
-  typedef P2< Real4, Real8 > R2xR2;
+  typedef P2< Real8, Real8 > R2xR2;
 
 }    // namespace bamg
 
@@ -88,7 +88,7 @@ namespace bamg {
   inline double OppositeAngle(double a) { return a < 0 ? Pi + a : a - Pi; }
 
 #ifdef DRAWING
-  extern Real4 xGrafCoef, yGrafCoef, xGrafOffSet, yGrafOffSet;
+  extern Real8 xGrafCoef, yGrafCoef, xGrafOffSet, yGrafOffSet;
   extern R2 GrafPMin, GrafPMax;
   extern Real8 Grafh;
 #endif
@@ -438,7 +438,7 @@ namespace bamg {
       return aa[i & 3] & 3;
     }    // Number of the  adjacent edge in adj tria
 
-    inline Real4 qualite( );
+    inline Real8 qualite( );
 
     void SetAdjAdj(Int1 a) {
       a &= 3;
@@ -1275,8 +1275,8 @@ namespace bamg {
     on = on->Adj[j];
   }
 
-  inline Real4 qualite(const Vertex &va, const Vertex &vb, const Vertex &vc) {
-    Real4 ret;
+  inline Real8 qualite(const Vertex &va, const Vertex &vb, const Vertex &vc) {
+    Real8 ret;
     I2 ia = va, ib = vb, ic = vc;
     I2 ab = ib - ia, bc = ic - ib, ac = ic - ia;
     Icoor2 deta = Det(ab, ac);
@@ -1318,7 +1318,7 @@ namespace bamg {
     };
   }
 
-  inline Real4 Triangle::qualite( ) { return det < 0 ? -1 : bamg::qualite(*ns[0], *ns[1], *ns[2]); }
+  inline Real8 Triangle::qualite( ) { return det < 0 ? -1 : bamg::qualite(*ns[0], *ns[1], *ns[2]); }
 
   Int4 inline Vertex::Optim(int i, int koption) {
     Int4 ret = 0;
@@ -1478,7 +1478,7 @@ namespace bamg {
 #endif
 
 #ifdef DRAWING
-  extern Real4 xGrafCoef, yGrafCoef, xGrafOffSet, yGrafOffSet;    // R2 -> I2 transform
+  extern Real8 xGrafCoef, yGrafCoef, xGrafOffSet, yGrafOffSet;    // R2 -> I2 transform
   extern R2 Gpmin, Gpmax;
   // extern Real8 Gh;
   // cf routine ILineTo IMoveto

--- a/src/bamglib/MeshDraw.cpp
+++ b/src/bamglib/MeshDraw.cpp
@@ -40,7 +40,7 @@ using namespace std;
 extern bool withrgraphique;
 
 namespace bamg {
-  Real4 xGrafCoef, yGrafCoef, xGrafOffSet, yGrafOffSet;
+  Real8 xGrafCoef, yGrafCoef, xGrafOffSet, yGrafOffSet;
   R2 GrafPMin, GrafPMax;
   Real8 Grafh = 0;
 
@@ -710,7 +710,7 @@ namespace bamg {
     R2 x, x50;
     int k = 0, k50 = 0;
     for (int ii = 0; ii < 100; ii++) {
-      x = F(Real4(ii) / 100.0);
+      x = F(Real8(ii) / 100.0);
       if (ii == 50) x50 = x, k50 = 1;
       if (InPtScreen(x.x, x.y)) {
         if (k)

--- a/src/bamglib/MeshGeom.cpp
+++ b/src/bamglib/MeshGeom.cpp
@@ -349,7 +349,7 @@ namespace bamg {
 
     edge4 = new SetOfEdges4(nbe, nbv);
 
-    Real4 *len = new Real4[Gh.nbv];
+    Real8 *len = new Real8[Gh.nbv];
     for (i = 0; i < Gh.nbv; i++) len[i] = 0;
     if (verbosity > 6) {
       int nbr = 0;
@@ -438,7 +438,7 @@ namespace bamg {
 
     for (i = 0; i < Gh.nbv; i++)
       if (Gh.vertices[i].color > 0)
-        Gh.vertices[i].m = Metric(len[i] / (Real4)Gh.vertices[i].color);
+        Gh.vertices[i].m = Metric(len[i] / (Real8)Gh.vertices[i].color);
       else
         Gh.vertices[i].m = Metric(hmin);
     delete[] len;

--- a/src/bamglib/MeshRead.cpp
+++ b/src/bamglib/MeshRead.cpp
@@ -105,7 +105,7 @@ namespace bamg {
         f_in >> identity;
       } else if (!strcmp(fieldname, "hVertices")) {
         hvertices = 1;
-        Real4 h;
+        Real8 h;
         for (i = 0; i < nbv; i++) {
           f_in >> h;
           vertices[i].m = Metric(h);
@@ -234,9 +234,9 @@ namespace bamg {
         if (verbosity > 5)
           cout << "     Record Edges: Nb of Edge " << nbe << " edges " << edges << endl;
         assert(edges);
-        Real4* len = 0;
+        Real8* len = 0;
         if (!hvertices) {
-          len = new Real4[nbv];
+          len = new Real8[nbv];
           for (i = 0; i < nbv; i++) len[i] = 0;
         }
         for (i = 0; i < nbe; i++) {
@@ -265,7 +265,7 @@ namespace bamg {
         if (!hvertices) {
           for (i = 0; i < nbv; i++)
             if (vertices[i].color > 0)
-              vertices[i].m = Metric(len[i] / (Real4)vertices[i].color);
+              vertices[i].m = Metric(len[i] / (Real8)vertices[i].color);
             else
               vertices[i].m = Metric(hmin);
           delete[] len;
@@ -872,7 +872,7 @@ namespace bamg {
         if (verbosity > 5) cout << "     Geom Record hVertices nbv=" << nbv << endl;
         hvertices = 1;
         for (i = 0; i < nbv; i++) {
-          Real4 h;
+          Real8 h;
           f_in >> h;
           vertices[i].m = Metric(h);
         }
@@ -884,7 +884,7 @@ namespace bamg {
         }
         if (verbosity > 5) cout << "     Geom Record MetricVertices nbv =" << nbv << endl;
         for (i = 0; i < nbv; i++) {
-          Real4 a11, a21, a22;
+          Real8 a11, a21, a22;
           f_in >> a11 >> a21 >> a22;
           vertices[i].m = Metric(a11, a21, a22);
         }
@@ -897,7 +897,7 @@ namespace bamg {
         if (verbosity > 5) cout << "     Geom Record h1h2VpVertices nbv=" << nbv << endl;
 
         for (i = 0; i < nbv; i++) {
-          Real4 h1, h2, v1, v2;
+          Real8 h1, h2, v1, v2;
           f_in >> h1 >> h2 >> v1 >> v2;
           vertices[i].m = Metric(MatVVP2x2(1 / (h1 * h1), 1 / (h2 * h2), D2(v1, v2)));
         }
@@ -964,9 +964,9 @@ namespace bamg {
           if (verbosity > 5) cout << "     Record Edges: Nb of Edge " << nbe << endl;
           assert(edges);
           assert(nbv > 0);
-          Real4* len = 0;
+          Real8* len = 0;
           if (!hvertices) {
-            len = new Real4[nbv];
+            len = new Real8[nbv];
             for (i = 0; i < nbv; i++) len[i] = 0;
           }
 
@@ -997,7 +997,7 @@ namespace bamg {
           if (!hvertices) {
             for (i = 0; i < nbv; i++)
               if (vertices[i].color > 0)
-                vertices[i].m = Metric(len[i] / (Real4)vertices[i].color);
+                vertices[i].m = Metric(len[i] / (Real8)vertices[i].color);
               else
                 vertices[i].m = Metric(Hmin);
             delete[] len;

--- a/src/bamglib/Metric.h
+++ b/src/bamglib/Metric.h
@@ -44,10 +44,10 @@ namespace bamg {
 
   class MetricIso {
     friend class MatVVP2x2;
-    Real4 h;
+    Real8 h;
 
    public:
-    MetricIso(Real4 a) : h(a) {}
+    MetricIso(Real8 a) : h(a) {}
     MetricIso(const MetricAnIso M);    // {MatVVP2x2 vp(M);h=1/sqrt(Max(vp.lambda1,vp.lambda2));}
     MetricIso(Real8 a11, Real8 a21, Real8 a22);    // {*this=MetricAnIso(a11,a21,a22));}
     MetricIso( ) : h(1){};                         //
@@ -71,7 +71,7 @@ namespace bamg {
     MetricIso operator/(Real8 c) const { return MetricIso(h * c); }
     Real8 det( ) const { return 1. / (h * h * h * h); }
     operator D2xD2( ) { return D2xD2(1 / (h * h), 0., 0., 1 / (h * h)); }
-    void Box(Real4& hx, Real4& hy) { hx = h, hy = h; }
+    void Box(Real8& hx, Real8& hy) { hx = h, hy = h; }
     friend ostream& operator<<(ostream& f, const MetricIso& M) {
       f << " h=" << M.h << ";";
       return f;
@@ -114,7 +114,7 @@ namespace bamg {
     Real8 operator( )(R2 x, R2 y) const {
       return x.x * y.x * a11 + (x.x * x.y + x.y * y.x) * a21 + x.y * y.y * a22;
     };
-    inline void Box(Real4& hx, Real4& hy) const;
+    inline void Box(Real8& hx, Real8& hy) const;
     friend ostream& operator<<(ostream& f, const MetricAnIso& M) {
       f << " mtr a11=" << M.a11 << " a21=a12=" << M.a21 << " a22=" << M.a22 << ";";
       return f;
@@ -204,7 +204,7 @@ namespace bamg {
     a22 = v00 * M.lambda2 + v11 * M.lambda1;
   }
 
-  inline void MetricAnIso::Box(Real4& hx, Real4& hy) const {
+  inline void MetricAnIso::Box(Real8& hx, Real8& hy) const {
     Real8 d = a11 * a22 - a21 * a21;
     hx = sqrt(a22 / d);
     hy = sqrt(a11 / d);

--- a/src/bamglib/meshtype.h
+++ b/src/bamglib/meshtype.h
@@ -65,7 +65,6 @@ namespace bamg {
     return Min(Min(a, b), c);
   }
 
-  typedef float Real4;
   typedef double Real8;
   typedef short Int1;
   typedef short Int2;

--- a/src/femlib/BamgFreeFem.cpp
+++ b/src/femlib/BamgFreeFem.cpp
@@ -596,10 +596,10 @@ const Fem2D::Mesh *  BuildMesh(Stack stack,const  Fem2D::MeshL **ppmshL , int nb
     cout <<"\t\t"  << "     Record Edges: Nb of Edge " << Gh->nbe <<endl;
   throwassert(Gh->edges);
   throwassert (Gh->nbv >0);
-  Real4 *len =0;
+  Real8 *len =0;
   if (!hvertices)
     {
-      len = new Real4[Gh->nbv];
+      len = new Real8[Gh->nbv];
       for(i=0;i<Gh->nbv;i++)
         len[i]=0;
     }
@@ -717,7 +717,7 @@ const Fem2D::Mesh *  BuildMesh(Stack stack,const  Fem2D::MeshL **ppmshL , int nb
 
         }
         else if (Gh->vertices[i].color > 0)
-          Gh->vertices[i].m=  Metric(len[i] /(Real4) Gh->vertices[i].color);
+          Gh->vertices[i].m=  Metric(len[i] /(Real8) Gh->vertices[i].color);
         else
           Gh->vertices[i].m=  Metric(Hmin);
       }
@@ -1017,10 +1017,10 @@ const Fem2D::Mesh *  BuildMesh(Stack stack, E_BorderN const * const & b,bool jus
     cout <<"\t\t"  << "     Record Edges: Nb of Edge " << Gh->nbe <<endl;
   throwassert(Gh->edges);
   throwassert (Gh->nbv >0);
-  Real4 *len =0;
+  Real8 *len =0;
   if (!hvertices)
     {
-      len = new Real4[Gh->nbv];
+      len = new Real8[Gh->nbv];
       for(i=0;i<Gh->nbv;i++)
         len[i]=0;
     }
@@ -1093,7 +1093,7 @@ const Fem2D::Mesh *  BuildMesh(Stack stack, E_BorderN const * const & b,bool jus
 
         }
         else if (Gh->vertices[i].color > 0)
-          Gh->vertices[i].m=  Metric(len[i] /(Real4) Gh->vertices[i].color);
+          Gh->vertices[i].m=  Metric(len[i] /(Real8) Gh->vertices[i].color);
         else
           Gh->vertices[i].m=  Metric(Hmin);
       }

--- a/src/femlib/fem.cpp
+++ b/src/femlib/fem.cpp
@@ -1915,7 +1915,7 @@ Mesh::Mesh(const Mesh & Th,int * split,bool WithMortar,int label)
         long iseuil =(long) (quadtree->coef*seuil);
         long iseuilhm = (long) (quadtree->coef*hm);
         if(iseuilhm == 0){
-          cerr << " The generatated 2d mesh is too fine: hmin = " << hm << " < " << 1./quadtree->coef << endl;
+          cerr << " The generated 2d mesh is too fine: hmin = " << hm << " < " << 1./quadtree->coef << endl;
           ffassert(0); 
         }
         if( verbosity>5 && ! iseuil )

--- a/src/femlib/fem.cpp
+++ b/src/femlib/fem.cpp
@@ -1913,11 +1913,10 @@ Mesh::Mesh(const Mesh & Th,int * split,bool WithMortar,int label)
 	nv =0;
 	quadtree = new FQuadTree(this,Pmin,Pmax,nv); // build empty the quadtree
         long iseuil =(long) (quadtree->coef*seuil);
-        long iseuilhm = (long) (quadtree->coef*hm*0.8);
-        if( iseuilhm ==0)
-        {
-            cerr << " The generatated 2d mesh is to fine :  hmin = " << hm << " to to small < "<< 1./quadtree->coef  << endl;
-            ffassert(0); 
+        long iseuilhm = (long) (quadtree->coef*hm);
+        if(iseuilhm == 0){
+          cerr << " The generatated 2d mesh is too fine: hmin = " << hm << " < " << 1./quadtree->coef << endl;
+          ffassert(0); 
         }
         if( verbosity>5 && ! iseuil )
          cout << " seuil = " <<  seuil << " hmin = " << hm << " iseuil/ quadtree: " << iseuil << " coef quadtree " <<  quadtree->coef << endl;


### PR DESCRIPTION
This is not really a bug fix, but rather a suggestion for possible code improvement... Please feel free to dismiss.
Why are single precision floating point integers used only sometimes? I have found at least one case where the previous (mixed single and double precision) workflow causes errors in mesh adaptation that are not encountered after this change.