### PR TITLE
Fix 9c53e8a2e wrong space character

### DIFF
--- a/src/femlib/MeshLn.cpp
+++ b/src/femlib/MeshLn.cpp
@@ -555,7 +555,7 @@ namespace Fem2D
     PlotStream f(ff);
     string s;
     f >> s;
-    ffassert( s== GsbeginL || s== "MeshS::GSave v0"); // to by pass bug 
+    ffassert( s == GsbeginL || s == "MeshS::GSave v0"); // to by pass bug 
     f >> nv >> nt >> nbe;
     if(verbosity>2)
       cout << " GRead : nv " << nv << " " << nt << " " << nbe << endl;


### PR DESCRIPTION
The character between '||' and 's=='  is a 'non breaking space' (0xA0), and isn't interpreted as a space character (0x20) by all the compilers. It failed on Ubuntu 22.04/24.04 with respectively gcc11/13 (see https://github.com/FreeFem/FreeFem-sources/actions/runs/14173041518/job/39701108948). While it visually doesn't change anything :), I replaced it with a regular space character.
