### PR TITLE
supports SNES custom monitor; fixes SNES convergence test

### DIFF
--- a/examples/hpddm/newton-2d-PETSc.edp
+++ b/examples/hpddm/newton-2d-PETSc.edp
@@ -51,6 +51,9 @@ func int funcJ(real[int]& inPETSc) {
     A = vhJ(Vh, Vh, tgv = -1);
     return 0;
 }
+func int funcMonitor(int it, real norm, real[int]& inPETSc){
+    if(mpirank==0) cout << "SNES iter: " << it << ", residual norm: " << norm << endl;
+}
 
 real[int] xPETSc, bPETSc;
 u[] = vC(0, Vh);
@@ -58,7 +61,8 @@ ChangeNumbering(A, u[], bPETSc);
 xPETSc.resize(bPETSc.n);
 xPETSc = 0;
 int ret;
-SNESSolve(A, funcJ, funcRes, bPETSc, xPETSc, sparams = "-snes_monitor -ksp_monitor_true_residual -snes_converged_reason -ksp_converged_reason -pc_type lu -snes_view", reason = ret);
+SNESSolve(A, funcJ, funcRes, bPETSc, xPETSc, monitor = funcMonitor, reason = ret,
+        sparams = "-snes_monitor -ksp_monitor_true_residual -snes_converged_reason -ksp_converged_reason -pc_type lu -snes_view");
 assert(ret == 3);
 ChangeNumbering(A, u[], xPETSc, inverse = true, exchange = true);
 plotMPI(Th, u, Pk, def, real, cmm = "Global solution");
@@ -68,7 +72,7 @@ Vh v;
 int j;
 real absTol = 1e-2;
 macro myplot() cmm = "Global " + (j == 0 ? "solution" : "decrement") + " at iteration " + it, wait = 1, fill = 1, dim = 3// EOM
-func int funcMonitor(int it, real xnorm, real gnorm, real f, real[int]& u, real[int]& du) {
+func int funcConvergence(int it, real xnorm, real gnorm, real f, real[int]& u, real[int]& du) {
     ChangeNumbering(A, v[], u, inverse = true, exchange = true);
     j = 0;
     plotMPI(Th, v, Pk, def, real, myplot);
@@ -79,7 +83,7 @@ func int funcMonitor(int it, real xnorm, real gnorm, real f, real[int]& u, real[
     mpiAllReduce(abs, red, mpiCommWorld, mpiMAX);
     return it > 0 && red < absTol ? 2 : 0; // reasons defined there https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/SNES/SNESConvergedReason.html
 }
-SNESSolve(A, funcJ, funcRes, bPETSc, xPETSc, sparams = "-snes_monitor -snes_converged_reason", monitor = funcMonitor, reason = ret);
+SNESSolve(A, funcJ, funcRes, bPETSc, xPETSc, sparams = "-snes_monitor -snes_converged_reason", monitor = funcMonitor, convergence = funcConvergence, reason = ret);
 assert(ret == 2);
 ChangeNumbering(A, u[], xPETSc, inverse = true, exchange = true);
 plotMPI(Th, u, Pk, def, real, cmm = "Global solution");

--- a/plugin/mpi/PETSc-code.hpp
+++ b/plugin/mpi/PETSc-code.hpp
@@ -2161,6 +2161,7 @@ namespace PETSc {
   struct _n_User< NonlinearSolver< Type > > {
     typename NonlinearSolver< Type >::VecF_O* op;
     typename LinearSolver< Type >::MatF_O* r;
+    typename NonlinearSolver< Type >::IMonF_O* mon;
     typename NonlinearSolver< Type >::IConvF_O* conv;
   };
   template< class Type >
@@ -4246,7 +4247,7 @@ namespace PETSc {
       Expression x;
       const OneOperator *codeJ, *codeR, *codeRHS;
       const int c;
-      static const int n_name_param = 12;
+      static const int n_name_param = 13;
       static basicAC_F0::name_and_type name_param[];
       Expression nargs[n_name_param];
       E_NonlinearSolver(const basicAC_F0& args, int d)
@@ -4323,7 +4324,9 @@ namespace PETSc {
     {"JacobianEquality", &typeid(Polymorphic*)},
     {"JI", &typeid(Type*)},
     {"JE", &typeid(Type*)},
-    {"reason", &typeid(long*)}};
+    {"reason", &typeid(long*)},
+    {"convergence", &typeid(Polymorphic*)}
+  };
   template< class Type >
   PetscErrorCode FormJacobian(SNES snes, Vec x, Mat J, Mat B, void* ctx) {
     User< Type >* user;
@@ -4338,6 +4341,23 @@ namespace PETSc {
     long ret = mat->apply(xx);
     VecRestoreArrayRead(x, &in);
     PetscFunctionReturn(PetscErrorCode(ret));
+  }
+  template<class Type>
+  PetscErrorCode Monitor(SNES snes, PetscInt it, PetscReal norm, void* ctx) {
+    User<Type>* user;
+    const PetscScalar* in;
+    Vec u;
+
+    PetscFunctionBeginUser;
+    user = reinterpret_cast< User< Type >* >(ctx);
+    typename NonlinearSolver< Type >::IMonF_O* mat =
+        reinterpret_cast<typename NonlinearSolver< Type >::IMonF_O* >((*user)->mon);
+    SNESGetSolution(snes, &u);
+    VecGetArrayRead(u, &in);
+    KN_< PetscScalar > xx(const_cast< PetscScalar* >(in), mat->x.n);
+    mat->apply(it, norm, xx);
+    VecRestoreArrayRead(u, &in);
+    PetscFunctionReturn(PETSC_SUCCESS);
   }
   template< class Type >
   PetscErrorCode Convergence(SNES snes, PetscInt it, PetscReal xnorm, PetscReal gnorm, PetscReal f,
@@ -4705,10 +4725,19 @@ namespace PETSc {
           if (op) {
             ffassert(op);
             const OneOperator* codeM =
-              op->Find("(", ArrayOfaType(atype< long >( ), atype< double >( ), atype< double >( ),
-                                         atype< double >( ), atype< KN< PetscScalar >* >( ),
-                                         atype< KN< PetscScalar >* >( ), false));
-            user->conv = new NonlinearSolver< Type >::IConvF_O(in->n, stack, codeM);
+              op->Find("(", ArrayOfaType(atype< long >( ), atype< double >( ),
+                                          atype< KN< PetscScalar >* >( ), false));
+            user->mon = new NonlinearSolver< Type >::IMonF_O(in->n, stack, codeM);
+            SNESMonitorSet(snes, Monitor< NonlinearSolver< Type > >, &user, NULL);
+          }
+          const Polymorphic* op2 = nargs[12] ? dynamic_cast< const Polymorphic* >(nargs[12]) : nullptr;
+          if (op2) {
+            ffassert(op2);
+            const OneOperator* codeC =
+              op2->Find("(", ArrayOfaType(atype< long >( ), atype< double >( ), atype< double >( ),
+                                          atype< double >( ), atype< KN< PetscScalar >* >( ),
+                                          atype< KN< PetscScalar >* >( ), false));
+            user->conv = new NonlinearSolver< Type >::IConvF_O(in->n, stack, codeC);
             SNESSetConvergenceTest(snes, Convergence< NonlinearSolver< Type > >, &user, NULL);
           }
           SNESSolve(snes, c == 1 ? f : NULL, x);


### PR DESCRIPTION
Adds support for user-defined SNES monitors through the named parameter `monitor = ...` and moves support for user-defined convergence tests to a new named parameter via `convergence = ...`