### PR TITLE
Remove condition on `fields` and `names` in EPS fieldsplit to match KSP

### DIFF
--- a/plugin/mpi/SLEPc-code.hpp
+++ b/plugin/mpi/SLEPc-code.hpp
@@ -296,18 +296,16 @@ AnyType eigensolver<Type, K, SType>::E_eigensolver::operator()(Stack stack) cons
                         KN<String>* names = nargs[6] ? GetAny<KN<String>*>((*nargs[6])(stack)) : 0;
                         KN<Matrice_Creuse<upscaled_type<PetscScalar>>>* mS = nargs[7] ? GetAny<KN<Matrice_Creuse<upscaled_type<PetscScalar>>>*>((*nargs[7])(stack)) : 0;
                         KN<double>* pL = nargs[8] ? GetAny<KN<double>*>((*nargs[8])(stack)) : 0;
-                        if(fields && names) {
-                            KSP ksp;
-                            STGetKSP(st, &ksp);
-                            KSPSetOperators(ksp, ptA->_petsc, ptA->_petsc);
-                            setFieldSplitPC(ptA, ksp, fields, names, mS, pL);
-                            EPSSetUp(eps);
-                            if(ptA->_vS && !ptA->_vS->empty()) {
-                                PC pc;
-                                KSPGetPC(ksp, &pc);
-                                PCSetUp(pc);
-                                PETSc::setCompositePC(pc, ptA->_vS);
-                            }
+                        KSP ksp;
+                        STGetKSP(st, &ksp);
+                        KSPSetOperators(ksp, ptA->_petsc, ptA->_petsc);
+                        setFieldSplitPC(ptA, ksp, fields, names, mS, pL);
+                        EPSSetUp(eps);
+                        if(ptA->_vS && !ptA->_vS->empty()) {
+                            PC pc;
+                            KSPGetPC(ksp, &pc);
+                            PCSetUp(pc);
+                            PETSc::setCompositePC(pc, ptA->_vS);
                         }
                     }
                 }

--- a/plugin/mpi/SLEPc-code.hpp
+++ b/plugin/mpi/SLEPc-code.hpp
@@ -296,7 +296,6 @@ AnyType eigensolver<Type, K, SType>::E_eigensolver::operator()(Stack stack) cons
                         KN<String>* names = nargs[6] ? GetAny<KN<String>*>((*nargs[6])(stack)) : 0;
                         KN<Matrice_Creuse<upscaled_type<PetscScalar>>>* mS = nargs[7] ? GetAny<KN<Matrice_Creuse<upscaled_type<PetscScalar>>>*>((*nargs[7])(stack)) : 0;
                         KN<double>* pL = nargs[8] ? GetAny<KN<double>*>((*nargs[8])(stack)) : 0;
-                        KSP ksp;
                         STGetKSP(st, &ksp);
                         KSPSetOperators(ksp, ptA->_petsc, ptA->_petsc);
                         setFieldSplitPC(ptA, ksp, fields, names, mS, pL);


### PR DESCRIPTION
I noticed that I have to define `names` when using `PCFIELDSPLIT` with an `EPSSolve`, but not with a normal `KSPSolve`. Compare lines ~300 in [SLEPc-code.hpp](https://github.com/FreeFem/FreeFem-sources/blob/c9c54a78d53ac9f53189e538c77efc087e414e65/plugin/mpi/SLEPc-code.hpp#L299) to lines ~2600 in [PETSc-code.hpp](https://github.com/FreeFem/FreeFem-sources/blob/c9c54a78d53ac9f53189e538c77efc087e414e65/plugin/mpi/PETSc-code.hpp#L2600).