### PR TITLE
[CI] Tests fail properly and logs are printed

### DIFF
--- a/.github/workflows/full-mpich.yml
+++ b/.github/workflows/full-mpich.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - develop
       - master
-      - slegrand-actions-debug
 
   pull_request:
     branches:
@@ -73,8 +72,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install
@@ -150,8 +148,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install

--- a/.github/workflows/full-msmpi.yml
+++ b/.github/workflows/full-msmpi.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - develop
       - master
-      - slegrand-actions-debug
 
   pull_request:
     branches:
@@ -106,6 +105,5 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh

--- a/.github/workflows/full-openmpi.yml
+++ b/.github/workflows/full-openmpi.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - develop
       - master
-      - slegrand-actions-debug
 
   pull_request:
     branches:
@@ -73,8 +72,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - master
-      - slegrand-actions-debug
 
   pull_request:
     branches:
@@ -49,8 +48,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install
@@ -88,8 +86,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install
@@ -139,6 +136,5 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - master
-      - slegrand-actions-debug
 
   pull_request:
     branches:
@@ -51,8 +50,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install
@@ -89,8 +87,7 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh
 
       - name: Install
@@ -146,6 +143,5 @@ jobs:
 
       - name: Check
         run: |
-          make check
-          echo "Tests failed: " $(grep :test-result examples/*/*.trs | grep FAIL | wc -l)
+          make check -i
           ./etc/actions/failed_tests_logs.sh

--- a/etc/actions/failed_tests_logs.sh
+++ b/etc/actions/failed_tests_logs.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
-FAILED_TESTS=( $(grep :test-result examples/*/*.trs | grep FAIL) )
+# This script checks if tests have failed. If yes, it prints the content of the
+# failed tests log, and returns 1.
+#
+# It allows keeping the '-i' option for 'make check', print the failed
+# tests, and only then, return exit 1 to interrupt the CI pipeline.
 
-for val in ${FAILED_TESTS[@]/#*FAIL/}
-do
-    IFS="::"
-    read -ra path <<< $val
+FAILED_TESTS=$(grep ":test-result: FAIL" examples/*/*.trs)
+
+if [ -z "$FAILED_TESTS" ]; then
+    exit 0;
+fi
+
+NB_FAILED_TESTS=$(echo "$FAILED_TESTS" | wc -l)
+echo "$NB_FAILED_TESTS tests failed:"
+
+echo "$FAILED_TESTS" | while IFS= read -r line; do
+    path="${line%::test-result: FAIL}"
     printf  "\n******** ${path%.*}.log ********\n\n"
     tail -n 100 ${path%.*}.log
-    unset IFS
-done;
+done
+
+exit 1


### PR DESCRIPTION
Previous `make check -i` didn't allow to trigger pipeline failure. Simply removing the `-i` option doesn't allow to print the failed tests log. So I delegate the parsing and the printing of the failed tests log to the [./etc/actions/failed_tests_logs.sh](./etc/actions/failed_tests_logs.sh) script, which returns 1 in case of failure.