### PR TITLE
Move -std=gnu23 from CC to CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,7 +196,6 @@ echo >config_LIB_INFO
 # Necessary compilers
 #  remove the flag -sdt=gnu++11 in the compileur CXX (FH jan 2024)
 ac_cv_prog_cxx_cxx11=no
-AC_PROG_CC
 AC_PROG_CXX
 #  echo " #### $CXX"
 AC_LANG(C++)
@@ -452,6 +451,26 @@ AC_ARG_ENABLE(c,AS_HELP_STRING([--disable-c],[No C compiler available (C BLAS ne
 if test "$enable_c" != no
 then
     AC_PROG_CC
+    case "$CC" in
+        *-std=*)
+            AC_MSG_NOTICE([Moving -std flag from CC to CFLAGS])
+            cc_std=
+            cc_keep=
+            for cc_flag in $CC
+            do
+                case "$cc_flag" in
+                    -std=*)
+                        cc_std="$cc_std $cc_flag"
+                        ;;
+                    *)
+                        cc_keep="$cc_keep $cc_flag"
+                        ;;
+                esac
+            done
+            CC=${cc_keep# }
+            CFLAGS="${cc_std# } $CFLAGS"
+            ;;
+    esac
     AM_PROG_CC_C_O
 else
 


### PR DESCRIPTION
The problem on MacOS 15 and 26 seems to come from gcc 15. At the end of configure, CC variable contains -std=gnu23 flag, which should be in CFLAGS instead (I think). When passed to CMake in mmg's Makefile, it crashed since CMake doesn't expect a flag in CMAKE_C_COMPILER.
It works with those mods, but I'm not sure it is the right strategy. Maybe -std=gnu23 should be directly split from CC and added to CFLAGS in the configure. What do you think?