### PR TITLE
Fix windows debug

### DIFF
--- a/.github/workflows/full-mpich.yml
+++ b/.github/workflows/full-mpich.yml
@@ -48,9 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         version:  ${{ fromJson(inputs.ubuntu_versions || '[22.04, 24.04, 26.04]') }}
-        build-type: ${{ fromJson(inputs.build_types || '["debug", "release"]') }}
+        build_type: ${{ fromJson(inputs.build_types || '["debug", "release"]') }}
 
-    name: Ubuntu ${{ matrix.version }} with ${{ matrix.build-type }} \
+    name: Ubuntu ${{ matrix.version }} with ${{ matrix.build_type }} \
             - ${{ github.workflow }}
     env:
       INSTALL_DIR: /usr/local
@@ -68,9 +68,9 @@ jobs:
       - name: Set configure flags and variables
         id: flags
         run: |
-          if [ "${{ matrix.build-type }}" = "debug" ]; then
+          if [ "${{ matrix.build_type }}" = "debug" ]; then
             echo "configure-flags=--enable-debug --enable-generic" >> $GITHUB_OUTPUT
-          elif [ "${{ matrix.build-type }}" = "release" ]; then
+          elif [ "${{ matrix.build_type }}" = "release" ]; then
             echo "configure-flags=--enable-optim --enable-generic" >> $GITHUB_OUTPUT
           fi
           echo "staging-dir=${{ github.workspace }}/install_staging" >> $GITHUB_OUTPUT
@@ -162,8 +162,8 @@ jobs:
       matrix:
         version: [14, 15, 26]
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: macOS ${{ matrix.version }} with ${{ matrix.cfg.opts }} \
       - ${{ github.workflow }}

--- a/.github/workflows/full-msmpi.yml
+++ b/.github/workflows/full-msmpi.yml
@@ -48,9 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         version:  ${{ fromJson(inputs.windows_versions || '[2025]') }}
-        build-type: ${{ fromJson(inputs.build-types || '["debug", "release"]') }}
+        build_type: ${{ fromJson(inputs.build_types || '["debug", "release"]') }}
 
-    name: Windows Server ${{ matrix.version }} ${{ matrix.build-type }} - ${{github.workflow}}
+    name: Windows Server ${{ matrix.version }} ${{ matrix.build_type }} - ${{github.workflow}}
     runs-on: windows-${{ matrix.version }}
 
     defaults:
@@ -99,9 +99,9 @@ jobs:
       - name: Set configure flags and variables
         id: flags
         run: |
-          if [ "${{ matrix.build-type }}" = "debug" ]; then
+          if [ "${{ matrix.build_type }}" = "debug" ]; then
             echo "configure-flags=--enable-debug --enable-generic" >> $GITHUB_OUTPUT
-          elif [ "${{ matrix.build-type }}" = "release" ]; then
+          elif [ "${{ matrix.build_type }}" = "release" ]; then
             echo "configure-flags=--enable-optim --enable-generic" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/full-msmpi.yml
+++ b/.github/workflows/full-msmpi.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         version:  ${{ fromJson(inputs.windows_versions || '[2025]') }}
-        build-type: ${{ fromJson(inputs.build-types || '["release"]') }}
+        build-type: ${{ fromJson(inputs.build-types || '["debug", "release"]') }}
 
     name: Windows Server ${{ matrix.version }} ${{ matrix.build-type }} - ${{github.workflow}}
     runs-on: windows-${{ matrix.version }}

--- a/.github/workflows/full-openmpi.yml
+++ b/.github/workflows/full-openmpi.yml
@@ -13,7 +13,7 @@ on:
 
   workflow_call:
     inputs:
-      build-types:
+      build_types:
         description: 'Build types as JSON array'
         required: false
         type: string
@@ -45,9 +45,9 @@ jobs:
       fail-fast: false
       matrix:
         version:  ${{ fromJson(inputs.versions || '[22.04, 24.04, 26.04]') }}
-        build-type: ${{ fromJson(inputs.build-types || '["debug", "release"]') }}
+        build_type: ${{ fromJson(inputs.build_types || '["debug", "release"]') }}
 
-    name: Ubuntu ${{ matrix.version }} with ${{ matrix.build-type }} \
+    name: Ubuntu ${{ matrix.version }} with ${{ matrix.build_type }} \
             - ${{ github.workflow }}
     env:
       INSTALL_DIR: /usr/local
@@ -65,9 +65,9 @@ jobs:
       - name: Set configure flags and variables
         id: flags
         run: |
-          if [ "${{ matrix.build-type }}" = "debug" ]; then
+          if [ "${{ matrix.build_type }}" = "debug" ]; then
             echo "configure-flags=--enable-debug --enable-generic" >> $GITHUB_OUTPUT
-          elif [ "${{ matrix.build-type }}" = "release" ]; then
+          elif [ "${{ matrix.build_type }}" = "release" ]; then
             echo "configure-flags=--enable-optim --enable-generic" >> $GITHUB_OUTPUT
           fi
           echo "staging-dir=${{ github.workspace }}/install_staging" >> $GITHUB_OUTPUT

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         version: [22.04, 24.04, 26.04]
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: Ubuntu ${{ matrix.version }} with ${{ matrix.cfg.opts }} - ${{ github.workflow }}
     runs-on: ubuntu-${{ matrix.version }}
@@ -60,8 +60,8 @@ jobs:
       matrix:
         version: [14, 15, 26]
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: macOS ${{ matrix.version }} with ${{ matrix.cfg.opts }} - ${{ github.workflow }}
     runs-on: macos-${{ matrix.version }}
@@ -97,8 +97,8 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: Windows Server 2025 with ${{ matrix.cfg.opts }} - ${{ github.workflow }}
     runs-on: windows-2025

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -97,6 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
+        - {opts: --enable-debug}
         - {opts: --enable-optim --enable-generic}
 
     name: Windows Server 2025 with ${{ matrix.cfg.opts }} - ${{ github.workflow }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -102,6 +102,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
+        - {opts: --enable-debug}
         - {opts: --enable-optim --enable-generic}
 
     name: Windows Server 2025 with ${{ matrix.cfg.opts }} - ${{github.workflow}}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         version: [22.04, 24.04, 26.04]
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: Ubuntu ${{ matrix.version }} with ${{ matrix.cfg.opts }} - ${{ github.workflow }}
     runs-on: ubuntu-${{ matrix.version }}
@@ -66,8 +66,8 @@ jobs:
       matrix:
         version: [14, 15, 26]
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: macOS ${{ matrix.version }} with ${{ matrix.cfg.opts }} - ${{ github.workflow }}
     runs-on: macos-${{ matrix.version }}
@@ -102,8 +102,8 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-        - {opts: --enable-debug}
-        - {opts: --enable-optim --enable-generic}
+          - {opts: --enable-debug}
+          - {opts: --enable-optim --enable-generic}
 
     name: Windows Server 2025 with ${{ matrix.cfg.opts }} - ${{github.workflow}}
     runs-on: windows-2025

--- a/configure.ac
+++ b/configure.ac
@@ -575,9 +575,7 @@ ff_mingw=no
 ff_fpic=yes
 case $ff_uname in
     CYGWIN*)
-	ff_fpic=no
-	#    ff_nocygwin=-mno-cygwin
-	AC_SUBST(GCCNOCYGWIN,$ff_nocygwin);;
+	ff_fpic=no;;
     MINGW*|MSYS_NT*)
         enable_cygwindll=no;;
 
@@ -616,20 +614,12 @@ CYGWIN*|MINGW*|MSYS_NT*)
 		# FFCS does not use the Cygwin MinGW compilers any more
 		if test $enable_ffcs = no
 		then
-		    CXXFLAGS="$CXXFLAGS $ff_nocygwin -I/usr/include/mingw"
-		    FFLAGS="$FFLAGS $ff_nocygwin"
-		    CFLAGS="$CFLAGS $ff_nocygwin -I/usr/include/mingw"
-                    AC_COMPILE_IFELSE([AC_LANG_SOURCE([int a;])],[],
-			[ff_nocygwin="";
-			    AC_MSG_NOTICE([Sorry $ff_nocygwin optio is wrong try whitout , but try with gcc-3.3])
-			    ])
-		    CXXFLAGS="$CXXFLAGS $ff_nocygwin -I/usr/include/mingw"
-		    FFLAGS="$FFLAGS $ff_nocygwin"
-		    CFLAGS="$CFLAGS $ff_nocygwin -I/usr/include/mingw"
-		    CNOFLAGS="$CNOFLAGS $ff_nocygwin -I/usr/include/mingw"
+		    CXXFLAGS="$CXXFLAGS -I/usr/include/mingw"
+		    CFLAGS="$CFLAGS -I/usr/include/mingw"
+		    CNOFLAGS="$CNOFLAGS -I/usr/include/mingw"
 		fi
 
-		LIBS="$LIBS $ff_nocygwin -mthreads -lws2_32 -lcomdlg32"
+		LIBS="$LIBS -mthreads -lws2_32 -lcomdlg32"
 		LIBSNOCONSOLE="-mwindows"
 
 		# FFCS uses a specific compiler, so we specify its libraries explicitely
@@ -639,8 +629,8 @@ CYGWIN*|MINGW*|MSYS_NT*)
 		    test -z "$MPIRUN" &&  MPIRUN=`which mpiexec.exe`
 		    if test "$enable_fortran" != no -a "$with_flib" != no ;   then
 			case "$F77" in
-	 		    *gfortran) FLIBS="$ff_nocygwin -lgfortran -lquadmath";;
-	 		    *g77) FLIBS="$ff_nocygwin -lg2c";;
+	 		    *gfortran) FLIBS="-lgfortran -lquadmath";;
+	 		    *g77) FLIBS="-lg2c";;
 			    *)   AC_MSG_ERROR([ Sorry no known FLIBS with this $F77  !]) ;;
 			esac
 		    fi

--- a/configure.ac
+++ b/configure.ac
@@ -619,8 +619,8 @@ CYGWIN*|MINGW*|MSYS_NT*)
 		    CNOFLAGS="$CNOFLAGS -I/usr/include/mingw"
 		    if test "$enable_debug" = yes;
 		    then
-		        # Increase the COFF relocation section size. Adress
-			# space isn't big enough otherwise.
+		        # Increase the COFF relocation section size. Address
+			# space isn't large enough otherwise.
 			# See: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-relocations-object-only
 		        CXXFLAGS="$CXXFLAGS -Wa,-mbig-obj"
 		    	CFLAGS="$CFLAGS -Wa,-mbig-obj"

--- a/configure.ac
+++ b/configure.ac
@@ -617,6 +617,14 @@ CYGWIN*|MINGW*|MSYS_NT*)
 		    CXXFLAGS="$CXXFLAGS -I/usr/include/mingw"
 		    CFLAGS="$CFLAGS -I/usr/include/mingw"
 		    CNOFLAGS="$CNOFLAGS -I/usr/include/mingw"
+		    if test "$enable_debug" = yes;
+		    then
+		        # Increase the COFF relocation section size. Adress
+			# space isn't big enough otherwise.
+			# See: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-relocations-object-only
+		        CXXFLAGS="$CXXFLAGS -Wa,-mbig-obj"
+		    	CFLAGS="$CFLAGS -Wa,-mbig-obj"
+		    fi
 		fi
 
 		LIBS="$LIBS -mthreads -lws2_32 -lcomdlg32"

--- a/plugin/seq/shell.cpp
+++ b/plugin/seq/shell.cpp
@@ -98,9 +98,13 @@ long ff_mkdir(string *c) {
 }
 
 long ff_stat(string *c) {
+#ifdef _WIN32
+  struct _stat64 buff;
+  return _stat64(c->c_str( ), &buff);
+#else
   struct stat buff;
-
   return stat(c->c_str( ), &buff);
+#endif
 }
 
 long ff_isdir(string *c) {

--- a/plugin/seq/shell.cpp
+++ b/plugin/seq/shell.cpp
@@ -104,13 +104,18 @@ long ff_stat(string *c) {
 }
 
 long ff_isdir(string *c) {
-  struct stat buff;
-
-  if (0 == stat(c->c_str( ), &buff)) {
-    return (buff.st_mode & S_IFDIR) ? 1 : 0;
-  } else {
-    return -1;    // err
+#ifdef _WIN32
+  struct _stat64 buff;
+  if (0 == _stat64(c->c_str(), &buff)) {
+    return (buff.st_mode & _S_IFDIR) ? 1 : 0;
   }
+#else
+  struct stat buff;
+  if (0 == stat(c->c_str(), &buff)) {
+    return (buff.st_mode & S_IFDIR) ? 1 : 0;
+  }
+#endif
+  return -1;
 }
 
 DIR **OpenDir(DIR **pp, string *n) {

--- a/src/bin-win32/Makefile.am
+++ b/src/bin-win32/Makefile.am
@@ -80,35 +80,35 @@ win32-dll-target: FreeFem++.exe FreeFem++-nw.exe bamg.exe cvmsh2.exe launchff++.
 endif
 
 libff.dll: $(FFD_OBJ0) $(FFD_OBJ_AR) $(FFD_OBJ_AC) $(FFD_OBJ_AL) $(FFD_OBJ1) $(FFD_OBJ2) ../lglib/lg.tab.o
-	$(CXX) $(GCCNOCYGWIN) -shared -Wl,--enable-auto-import $^ -o $@ $(LDADD2)
+	$(CXX) -shared -Wl,--enable-auto-import $^ -o $@ $(LDADD2)
 
 parallelempi-empty.o:../mpi/parallelempi-empty.cpp
 	$(CXX) $(CXXFLAGS) $< -c -o $@
 
 FreeFem++-nw.exe: ../Graphics/sansrgraph.o parallelempi-empty.o ../lglib/mymain.o $(LIBS_FF)
-	$(CXX) $(GCCNOCYGWIN) libff.dll $^ -o $@ -lcomdlg32
+	$(CXX) libff.dll $^ -o $@ -lcomdlg32
 
 # ALH - 28/7/14 - the new automake default is to place the objects in
 # the same directory as the corresponding source file
 
 FreeFem++.exe: ../Graphics/sansrgraph.o parallelempi-empty.o ../lglib/mymain.o $(LIBS_FF)
-	$(CXX) $(GCCNOCYGWIN) libff.dll $^ -o $@ -lcomdlg32
+	$(CXX) libff.dll $^ -o $@ -lcomdlg32
 
 ## FH.. Strange : pb with MPI finaly with ffapi-mpi.dll ( J'ai compris)
 ## dur dur ...
 ## on mais init ffpt dans mymain.cpp
 FreeFem++-mpi.exe:	../Graphics/sansrgraph.o ../mpi/parallelempi.o ../lglib/mymain.o $(LIBS_FFmpi)
-	$(MPICXX) $(GCCNOCYGWIN) libff.dll $^ -o $@ -lcomdlg32 $(MPI_LIB)
+	$(MPICXX) libff.dll $^ -o $@ -lcomdlg32 $(MPI_LIB)
 bamg.exe: libff.dll $(LIBS_FF)
-	$(CXX) $(GCCNOCYGWIN) ../bamg/bamg.o -Wl,--enable-auto-import $^ -o $@
+	$(CXX) ../bamg/bamg.o -Wl,--enable-auto-import $^ -o $@
 cvmsh2.exe: $(LIBS_FF)
-	$(CXX) $(GCCNOCYGWIN) -Wl,--enable-auto-import ../bamg/cvmsh2.o $^ -o $@
+	$(CXX) -Wl,--enable-auto-import ../bamg/cvmsh2.o $^ -o $@
 drawbdmesh.exe:../std/Pcrgraph.o ../bamg/drawbdmesh.o $(LIBS_FF)
-	$(CXX) $(GCCNOCYGWIN) -mwindows -Wl,--enable-auto-import $^ -o $@
-launchff++.exe:launchff++.cpp
-	$(CXX) $(GCCNOCYGWIN) launchff++.cpp -o launchff++.exe -lcomdlg32
+	$(CXX) -mwindows -Wl,--enable-auto-import $^ -o $@
+launchff++.exe: launchff++.cpp
+	$(CXX) launchff++.cpp -o launchff++.exe -lcomdlg32
 md2edp.exe:../../etc/tools/md2edp.cpp 
-	$(CXX) $(GCCNOCYGWIN) ../../etc/tools/md2edp.cpp  -o md2edp.exe -lcomdlg32
+	$(CXX) ../../etc/tools/md2edp.cpp  -o md2edp.exe -lcomdlg32
 ff-c++:../../plugin/seq/load.link.in
 	../../config.status --file=ff-c++:$<
 	chmod a+x ff-c++


### PR DESCRIPTION
Fix of the compilation errors like:
```bash
(.pdata$_ZNK10E_F_F0_OptI6ResizeI2KNIPKN5Fem2D4MeshEEEPS6_Lb1EEclEPv+0x0): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32NB against `.text$_ZNK10E_F_F0_OptI6ResizeI2KNIPKN5Fem2D4MeshEEEPS6_Lb1EEclEPv'
```
on Windows in Debug mode. According to [the doc](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-relocations-object-only), the address space of the 'relocation section' is only 32 bits large. Since some symbols couldn't fit into this section, it led to many subsequent 'undefined reference'. Adding the "-Wa,-mbig-obj" assembler flag fixes the problem by increasing the size of the relocation section.
There are still errors during the 'make check' phase, but it seems a good beginning, we can debug under Windows.

I also removed unused ff_nocygwin variable